### PR TITLE
Refactor Robot Model Factory

### DIFF
--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -77,7 +77,7 @@ class RobotModels:
     def full_robot_model(self) -> pin.Model:
         """Full robot model."""
         if self._full_robot_model is None:
-            raise AttributeError("Robot model has not been initialized yet.")
+            raise AttributeError("Full robot model has not been initialized yet.")
         return self._full_robot_model
 
     @property
@@ -125,9 +125,8 @@ class RobotModels:
                 self._visual_model,
             ) = pin.buildModelsFromUrdf(
                 self._params.urdf_path,
-                self._robot_model,
                 self._params.urdf_meshes_dir,
-                self._params.free_flyer,
+                pin.JointModelFreeFlyer() if self._params.free_flyer else None,
             )
         except Exception as e:
             raise ValueError(
@@ -203,7 +202,7 @@ class RobotModels:
 
     def _update_collision_model_to_self_collision(self) -> None:
         """Update the collision model to self collision."""
-        pin.addAllCollisionPairs(self._collision_model)
+        self._collision_model.addAllCollisionPairs()
         pin.removeCollisionPairs(
             self._robot_model, self._collision_model, self._params.srdf_path
         )

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -28,6 +28,9 @@ class RobotModelParameters:
     armature: npt.NDArray[np.float64] = field(
         default_factory=lambda: np.array([], dtype=np.float64)
     )  # Default empty NumPy array
+    collision_color: npt.NDArray[np.float64] = (
+        np.array([249.0, 136.0, 126.0, 125.0]) / 255.0
+    )  # Red color for the collision model
 
     def __post_init__(self):
         # Check q0 is not empty

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -15,9 +15,9 @@ class RobotModelParameters:
     )  # Initial configuration of the robot
     free_flyer: bool = False  # True if the robot has a free flyer
     locked_joint_names: list[str] = field(default_factory=list)
-    urdf_path: str | Path = Path()  # Path to the URDF file
-    srdf_path: str | Path | None = None  # Path to the SRDF file
-    urdf_meshes_dir: str | Path | None = (
+    urdf_path: Path = Path()  # Path to the URDF file
+    srdf_path: Path | None = None  # Path to the SRDF file
+    urdf_meshes_dir: Path | None = (
         Path()  # Path to the directory containing the meshes and the URDF file.
     )
     collision_as_capsule: bool = (
@@ -51,10 +51,10 @@ class RobotModelParameters:
             )
 
         # Ensure paths are valid strings
-        if not Path(self.urdf_path).is_file():
+        if not self.urdf_path.is_file():
             raise ValueError("urdf_path must be a valid file path.")
 
-        if self.srdf_path is not None and not Path(self.srdf_path).is_file():
+        if self.srdf_path is not None and not self.srdf_path.is_file():
             raise ValueError("srdf_path must be a valid file path.")
 
 
@@ -170,7 +170,7 @@ class RobotModels:
                     ),
                     placement=geom_object.placement,
                 )
-                capsule.meshColor = np.array([249, 136, 126, 125]) / 255  # Red color
+                capsule.meshColor = self._params.collision_color
                 self._collision_model.addGeometryObject(capsule)
                 self._collision_model.removeGeometryObject(geom_object.name)
 

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -185,8 +185,8 @@ class RobotModels:
                 list_names_capsules.append(name)
                 capsule = pin.GeometryObject(
                     name=name,
-                    parent_frame=int(geom_object.parentFrame),
-                    parent_joint=int(geom_object.parentJoint),
+                    parent_frame=geom_object.parentFrame,
+                    parent_joint=geom_object.parentJoint,
                     collision_geometry=coal.Capsule(
                         geometry.radius, geometry.halfLength
                     ),

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -15,11 +15,11 @@ class RobotModelParameters:
     )  # Initial configuration of the robot
     free_flyer: bool = False  # True if the robot has a free flyer
     locked_joint_names: list[str] = field(default_factory=list)
-    urdf_path: Path = Path()  # Path to the URDF file
-    srdf_path: Path | None = None  # Path to the SRDF file
-    urdf_meshes_dir: Path = (
-        Path()
-    )  # Path to the directory containing the meshes and the URDF file.
+    urdf_path: str = "path/to/urdf"  # Path to the URDF file
+    srdf_path: str | None = None  # Path to the SRDF file
+    urdf_meshes_dir: str | None = (
+        None  # Path to the directory containing the meshes and the URDF file.
+    )
     collision_as_capsule: bool = (
         False  # True if the collision model should be reduced to capsules.
     )
@@ -49,10 +49,10 @@ class RobotModelParameters:
             )
 
         # Ensure paths are valid strings
-        if not isinstance(self.urdf_path, Path) or not self.urdf_path:
+        if not isinstance(self.urdf_path, str) or not self.urdf_path:
             raise ValueError("urdf_path must be a non-empty string.")
 
-        if self.srdf_path is not None and not isinstance(self.srdf_path, Path):
+        if self.srdf_path is not None and not isinstance(self.srdf_path, str):
             raise ValueError("srdf_path must be a Path or None.")
 
 
@@ -125,6 +125,7 @@ class RobotModels:
                 self._visual_model,
             ) = pin.buildModelsFromUrdf(
                 self._params.urdf_path,
+                self._robot_model,
                 self._params.urdf_meshes_dir,
                 self._params.free_flyer,
             )

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -148,29 +148,6 @@ class RobotModels:
             self._full_robot_model, joints_to_lock, self._q0
         )
 
-    def _get_joints_to_lock(self) -> list[int]:
-        """Get the joints ID to lock.
-
-        Raises:
-            ValueError: Joint name not found in the robot model.
-
-        Returns:
-            list[int]: List of joint IDs to lock.
-        """
-        joints_to_lock = []
-        for jn in self._params.locked_joint_names:
-            if self._full_robot_model.existJointName(jn):
-                joints_to_lock.append(self._full_robot_model.getJointId(jn))
-            else:
-                raise ValueError(f"Joint {jn} not found in the robot model.")
-        return joints_to_lock
-
-    def _load_reduced_model(self) -> None:
-        """Load the reduced robot model."""
-        joints_to_lock = self._get_joints_to_lock()
-        self._robot_model = pin.buildReducedModel(
-            self._full_robot_model, joints_to_lock, self._q0
-        )
 
     def _update_collision_model_to_capsules(self) -> None:
         """Update the collision model to capsules."""

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -119,7 +119,7 @@ class RobotModelFactory:
                 joints_to_lock.append(self._full_robot_model.getJointId(jn))
             else:
                 raise ValueError(f"Joint {jn} not found in the robot model.")
-            
+
         self._robot_model = pin.buildReducedModel(
             self._full_robot_model, joints_to_lock, self._q0
         )

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -16,7 +16,7 @@ class RobotModelParameters:
     free_flyer: bool = False  # True if the robot has a free flyer
     locked_joint_names: list[str] = field(default_factory=list)
     urdf_path: Path = Path()  # Path to the URDF file
-    srdf_path: Path = Path()  # Path to the SRDF file
+    srdf_path: Path | None = None  # Path to the SRDF file
     urdf_meshes_dir: Path = (
         Path()
     )  # Path to the directory containing the meshes and the URDF file.
@@ -49,11 +49,11 @@ class RobotModelParameters:
             )
 
         # Ensure paths are valid strings
-        if not isinstance(self.urdf_path, str) or not self.urdf_path:
+        if not isinstance(self.urdf_path, Path) or not self.urdf_path:
             raise ValueError("urdf_path must be a non-empty string.")
 
-        if not isinstance(self.srdf_path, str):
-            raise ValueError("srdf_path must be a string.")
+        if self.srdf_path is not None and not isinstance(self.srdf_path, Path):
+            raise ValueError("srdf_path must be a Path or None.")
 
 
 class RobotModels:

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -65,6 +65,7 @@ class RobotModelFactory:
         self._robot_model = None
         self._collision_model = None
         self._visual_model = None
+        self._q0 = deepcopy(self._params.q0)
         self.load_models()  # Populate models
 
     @property
@@ -98,7 +99,7 @@ class RobotModelFactory:
     @property
     def q0(self) -> np.array:
         """Initial configuration of the robot."""
-        return self.q0
+        return self._q0
 
     def load_models(self) -> None:
         """Load and prepare robot models based on parameters."""
@@ -140,8 +141,8 @@ class RobotModelFactory:
         try:
             (
                 self._full_robot_model,
-                self.collision_model,
-                self.visual_model,
+                self._collision_model,
+                self._visual_model,
             ) = pin.buildModelsFromUrdf(
                 self._params.urdf_path,
                 self._params.urdf_meshes_dir,
@@ -156,7 +157,7 @@ class RobotModelFactory:
         """Load the reduced robot model."""
         joints_to_lock = self._get_joints_to_lock()
         self._robot_model = pin.buildReducedModel(
-            self._full_robot_model, joints_to_lock, self.q0
+            self._full_robot_model, joints_to_lock, self._q0
         )
 
     def _update_collision_model_to_capsules(self) -> None:

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -24,7 +24,7 @@ class RobotModelParameters:
         False  # True if the collision model should be reduced to capsules.
     )
     # By default, the collision model when convexified is a sum of spheres and cylinders, often representing capsules. Here, all the couples sphere cylinder sphere are replaced by hppfcl capsules.
-    self_collision: bool = False  # If True, the collision model takes into account collisions pairs written in the srdf file.
+    self_collision: bool = False  # If True, the collision model takes into account collision pairs written in the srdf file.
     armature: npt.NDArray[np.float64] = field(
         default_factory=lambda: np.array([], dtype=np.float64)
     )  # Default empty NumPy array

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -1,96 +1,155 @@
 from copy import deepcopy
 from dataclasses import dataclass
-import numpy as np
 from pathlib import Path
+
+import coal
+import numpy as np
+import numpy.typing as npt
 import pinocchio as pin
-from typing import Union
 
 
 @dataclass
 class RobotModelParameters:
-    q0_name = str()
-    free_flyer = False
-    locked_joint_names = []
-    urdf = Path() | str
-    srdf = Path() | str
-    collision_as_capsule = False
-    self_collision = False
+    q0: npt.NDArray[np.float64]  # Initial configuration of the robot
+    free_flyer = False  # True if the robot has a free flyer
+    locked_joint_names = []  # List of joint names to lock
+    urdf_path = Path() | str  # Path to the URDF file
+    srdf_path = Path() | str  # Path to the SRDF file
+    urdf_meshes_dir = (
+        Path() | str
+    )  # Path to the directory containing the meshes and the URDF file.
+    collision_as_capsule = (
+        False  # True if the collision model should be reduced to capsules.
+    )
+    # By default, the collision model when convexified is a sum of spheres and cylinders, often representing capsules. Here, all the couples sphere cylinder sphere are replaced by  HPPFCL capsules.
+    self_collision = False  # If True, the collision model takes into account collisions pairs written in the srdf file.
 
 
 class RobotModelFactory:
     """Parse the robot model, reduce it and filter the collision model."""
 
-    """Complete model of the robot."""
-    _complete_model = pin.Model()
-    """ Complete model of the robot with collision meshes. """
-    _complete_collision_model = pin.GeometryModel()
-    """ Complete model of the robot with visualization meshes. """
-    _complete_visual_model = pin.GeometryModel()
-    """ Reduced model of the robot. """
-    _rmodel = pin.Model()
-    """ Reduced model of the robot with visualization meshes. """
-    _rcmodel = pin.GeometryModel()
-    """ Reduced model of the robot with collision meshes. """
-    _rvmodel = pin.GeometryModel()
-    """ Default configuration q0. """
-    _q0 = np.array([])
-    """ Parameters of the model. """
-    _params = RobotModelParameters()
-    """ Path to the collisions environment. """
-    _env = Path()
+    def __init__(self, param: RobotModelParameters):
+        """Parse the robot model, reduce it and filter the collision model.
 
-    def load_model(self, param: RobotModelParameters, env: Union[Path, None]) -> None:
+        Args:
+            param (RobotModelParameters): Parameters to load the robot models.
+        """
         self._params = param
-        self._env = env
-        self._load_pinocchio_models(param.urdf, param.free_flyer)
-        self._load_default_configuration(param.srdf, param.q0_name)
-        self._load_reduced_model(param.locked_joint_names, param.q0_name)
-        self._update_collision_model(
-            env, param.collision_as_capsule, param.self_collision, param.srdf
+        self.load_models()
+
+    @property
+    def full_robot_model(self) -> pin.Model:
+        return self.full_robot_model
+
+    @property
+    def robot_model(self) -> pin.Model:
+        return self.robot_model
+
+    @property
+    def visual_model(self) -> pin.GeometryModel:
+        return self.visual_model
+
+    @property
+    def collision_model(self) -> pin.GeometryModel:
+        return self.collision_model
+
+    @property
+    def q0(self) -> np.array:
+        return self.q0
+
+    def load_models(self) -> None:
+        self._load_full_pinocchio_models()
+        if self._params.locked_joint_names is not None:
+            self._load_reduced_model()
+        else:
+            self.robot_model = deepcopy(self.full_robot_model)
+        if self._params.collision_as_capsule:
+            self._update_collision_model_to_capsules()
+        if self._params.self_collision:
+            self._update_collision_model_to_self_collision()
+
+    def _get_joints_to_lock(self) -> list[int]:
+        """Get the joints ID to lock.
+
+        Raises:
+            ValueError: Joint name not found in the robot model.
+
+        Returns:
+            list[int]: List of joint IDs to lock.
+        """
+        joints_to_lock = []
+        for jn in self._params.locked_joint_names:
+            if self.full_robot_model.existJointName(jn):
+                joints_to_lock.append(self.full_robot_model.getJointId(jn))
+            else:
+                raise ValueError(f"Joint {jn} not found in the robot model.")
+        return joints_to_lock
+
+    def _load_full_pinocchio_models(self) -> None:
+        """Load the full robot model, the visual model and the collision model."""
+        (
+            self.full_robot_model,
+            self.collision_model,
+            self.visual_model,
+        ) = pin.buildModelsFromUrdf(
+            self._params.urdf_path,
+            self._params.urdf_meshes_dir,
+            self._params.free_flyer,
         )
 
-    def _load_pinocchio_models(self, urdf: Path, free_flyer: bool) -> None:
-        pass
+    def _load_reduced_model(self) -> None:
+        """Load the reduced robot model."""
+        joints_to_lock = self._get_joints_to_lock()
+        self.robot_model = pin.buildReducedModel(
+            self.full_robot_model, joints_to_lock, self.q0
+        )
 
-    def _load_default_configuration(self, srdf_path: Path, q0_name: str) -> None:
-        pass
+    def _update_collision_model_to_capsules(self) -> None:
+        """Update the collision model to capsules."""
+        cmodel = self.collision_model.copy()
+        list_names_capsules = []
+        # Iterate through geometry objects in the collision model
+        for geom_object in cmodel.geometryObjects:
+            geometry = geom_object.geometry
+            # Remove superfluous suffix from the name
+            base_name = "_".join(geom_object.name.split("_")[:-1])
+            # Convert cylinders to capsules
+            if isinstance(geometry, coal.Cylinder):
+                name = self._generate_capsule_name(base_name, list_names_capsules)
+                list_names_capsules.append(name)
+                capsule = pin.GeometryObject(
+                    name=name,
+                    parent_frame=int(geom_object.parentFrame),
+                    parent_joint=int(geom_object.parentJoint),
+                    collision_geometry=coal.Capsule(
+                        geometry.radius, geometry.halfLength
+                    ),
+                    placement=geom_object.placement,
+                )
+                capsule.meshColor = np.array([249, 136, 126, 125]) / 255  # Red color
+                self.collision_model.addGeometryObject(capsule)
+                self.collision_model.removeGeometryObject(geom_object.name)
 
-    def _load_reduced_model(self, locked_joint_names, q0_name) -> None:
-        pass
+            # Remove spheres associated with links
+            elif isinstance(geometry, coal.Sphere) and "link" in geom_object.name:
+                self.collision_model.removeGeometryObject(geom_object.name)
 
-    def _update_collision_model(
-        self,
-        env: Union[Path, None],
-        collision_as_capsule: bool,
-        self_collision: bool,
-        srdf: Path,
-    ) -> None:
-        pass
+    def _update_collision_model_to_self_collision(self) -> None:
+        """Update the collision model to self collision."""
+        pin.addAllCollisionPairs(self.collision_model)
+        pin.removeCollisionPairs(
+            self.robot_model, self.collision_model, self._params.srdf_path
+        )
 
-    def create_complete_robot_model(self) -> pin.Model:
-        return self._complete_model.copy()
-
-    def create_complete_collision_model(self) -> pin.GeometryModel:
-        return self._complete_collision_model.copy()
-
-    def create_complete_visual_model(self) -> pin.GeometryModel:
-        return self._complete_visual_model.copy()
-
-    def create_reduced_robot_model(self) -> pin.Model:
-        return self._rmodel.copy()
-
-    def create_reduced_collision_model(self) -> pin.GeometryModel:
-        return self._rcmodel.copy()
-
-    def create_reduced_visual_model(self) -> pin.GeometryModel:
-        return self._rvmodel.copy()
-
-    def create_default_configuration(self) -> np.array:
-        return self._q0.copy()
-
-    def create_model_parameters(self) -> RobotModelParameters:
-        return deepcopy(self._params)
-
-    def print_model(self):
-        print("full model =\n", self._complete_model)
-        print("reduced model =\n", self._rmodel)
+    def _generate_capsule_name(self, base_name: str, existing_names: list) -> str:
+        """Generates a unique capsule name for a geometry object.
+        Args:
+            base_name (str): The base name of the geometry object.
+            existing_names (list): List of names already assigned to capsules.
+        Returns:
+            str: Unique capsule name.
+        """
+        i = 0
+        while f"{base_name}_capsule_{i}" in existing_names:
+            i += 1
+        return f"{base_name}_capsule_{i}"

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -24,9 +24,7 @@ class RobotModelParameters:
         False  # True if the collision model should be reduced to capsules.
     )
     # By default, the collision model when convexified is a sum of spheres and cylinders, often representing capsules. Here, all the couples sphere cylinder sphere are replaced by hppfcl capsules.
-    self_collision: bool = (
-        False  # If True, the collision model takes into account collisions pairs written in the srdf file.
-    )
+    self_collision: bool = False  # If True, the collision model takes into account collisions pairs written in the srdf file.
     armature: npt.NDArray[np.float64] = field(
         default_factory=lambda: np.array([], dtype=np.float64)
     )  # Default empty NumPy array

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -10,21 +10,25 @@ import pinocchio as pin
 
 @dataclass
 class RobotModelParameters:
-    q0: npt.NDArray[np.float64]  # Initial configuration of the robot
-    free_flyer = False  # True if the robot has a free flyer
+    q0: npt.NDArray[np.float64] = np.array(
+        [], dtype=np.float64
+    )  # Initial configuration of the robot
+    free_flyer: bool = False  # True if the robot has a free flyer
     locked_joint_names: list[str] = field(default_factory=list)
-    urdf_path = Path()  # Path to the URDF file
-    srdf_path = Path()  # Path to the SRDF file
-    urdf_meshes_dir = (
+    urdf_path: Path = Path()  # Path to the URDF file
+    srdf_path: Path = Path()  # Path to the SRDF file
+    urdf_meshes_dir: Path = (
         Path()
     )  # Path to the directory containing the meshes and the URDF file.
-    collision_as_capsule = (
+    collision_as_capsule: bool = (
         False  # True if the collision model should be reduced to capsules.
     )
     # By default, the collision model when convexified is a sum of spheres and cylinders, often representing capsules. Here, all the couples sphere cylinder sphere are replaced by hppfcl capsules.
-    self_collision = False  # If True, the collision model takes into account collisions pairs written in the srdf file.
+    self_collision: bool = (
+        False  # If True, the collision model takes into account collisions pairs written in the srdf file.
+    )
     armature: npt.NDArray[np.float64] = field(
-        default_factory=lambda: np.array([])
+        default_factory=lambda: np.array([], dtype=np.float64)
     )  # Default empty NumPy array
 
     def __post_init__(self):

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -15,10 +15,10 @@ class RobotModelParameters:
     )  # Initial configuration of the robot
     free_flyer: bool = False  # True if the robot has a free flyer
     locked_joint_names: list[str] = field(default_factory=list)
-    urdf_path: str = "path/to/urdf"  # Path to the URDF file
-    srdf_path: str | None = None  # Path to the SRDF file
-    urdf_meshes_dir: str | None = (
-        None  # Path to the directory containing the meshes and the URDF file.
+    urdf_path: str | Path = Path()  # Path to the URDF file
+    srdf_path: str | Path | None = None  # Path to the SRDF file
+    urdf_meshes_dir: str | Path | None = (
+        Path()  # Path to the directory containing the meshes and the URDF file.
     )
     collision_as_capsule: bool = (
         False  # True if the collision model should be reduced to capsules.
@@ -51,11 +51,11 @@ class RobotModelParameters:
             )
 
         # Ensure paths are valid strings
-        if not isinstance(self.urdf_path, str) or not self.urdf_path:
-            raise ValueError("urdf_path must be a non-empty string.")
+        if not Path(self.urdf_path).is_file():
+            raise ValueError("urdf_path must be a valid file path.")
 
-        if self.srdf_path is not None and not isinstance(self.srdf_path, str):
-            raise ValueError("srdf_path must be a Path or None.")
+        if self.srdf_path is not None and not Path(self.srdf_path).is_file():
+            raise ValueError("srdf_path must be a valid file path.")
 
 
 class RobotModels:
@@ -126,8 +126,8 @@ class RobotModels:
                 self._collision_model,
                 self._visual_model,
             ) = pin.buildModelsFromUrdf(
-                self._params.urdf_path,
-                self._params.urdf_meshes_dir,
+                str(self._params.urdf_path),
+                str(self._params.urdf_meshes_dir),
                 pin.JointModelFreeFlyer() if self._params.free_flyer else None,
             )
         except Exception as e:
@@ -206,7 +206,7 @@ class RobotModels:
         """Update the collision model to self collision."""
         self._collision_model.addAllCollisionPairs()
         pin.removeCollisionPairs(
-            self._robot_model, self._collision_model, self._params.srdf_path
+            self._robot_model, self._collision_model, str(self._params.srdf_path)
         )
 
     def _generate_capsule_name(self, base_name: str, existing_names: list[str]) -> str:

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -148,7 +148,6 @@ class RobotModels:
             self._full_robot_model, joints_to_lock, self._q0
         )
 
-
     def _update_collision_model_to_capsules(self) -> None:
         """Update the collision model to capsules."""
         cmodel = self._collision_model.copy()

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -1,7 +1,7 @@
 from os.path import dirname
 from pathlib import Path
 import unittest
-
+from copy import deepcopy
 import example_robot_data as robex
 import numpy as np
 
@@ -16,10 +16,11 @@ class TestRobotModelParameters(unittest.TestCase):
         urdf_path = robot.urdf
         srdf_path = robot.urdf.replace("urdf", "srdf")
         urdf_meshes_dir = dirname(dirname(robot.urdf))
+        free_flyer = False
         q0 = np.zeros(robot.model.nq)
         params = RobotModelParameters(
             q0=q0,
-            free_flyer=True,
+            free_flyer=free_flyer,
             locked_joint_names=["panda_joint1", "panda_joint2"],
             urdf_path=urdf_path,
             srdf_path=srdf_path,
@@ -30,7 +31,7 @@ class TestRobotModelParameters(unittest.TestCase):
         )
 
         self.assertTrue(np.array_equal(params.q0, q0))
-        self.assertEqual(params.free_flyer, True)
+        self.assertEqual(params.free_flyer, free_flyer)
         self.assertEqual(params.locked_joint_names, ["panda_joint1", "panda_joint2"])
         self.assertEqual(params.urdf_path, urdf_path)
         self.assertEqual(params.srdf_path, srdf_path)
@@ -78,3 +79,73 @@ class TestRobotModelParameters(unittest.TestCase):
                 params.collision_color, np.array([249.0, 136.0, 126.0, 125.0]) / 255.0
             )
         )
+
+
+class TestRobotModels(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        This method sets up the shared environment for all test cases in the class.
+        """
+        # Load the example robot model using example robot data to get the URDF path.
+        robot = robex.load("panda")
+        urdf_path = robot.urdf
+        srdf_path = robot.urdf.replace("urdf", "srdf")
+        urdf_meshes_dir = dirname(dirname(dirname(dirname(dirname(robot.urdf)))))
+        free_flyer = False
+        q0 = np.zeros(robot.model.nq)
+
+        # Store shared initial parameters
+        cls.shared_params = RobotModelParameters(
+            q0=q0,
+            free_flyer=free_flyer,
+            locked_joint_names=["panda_joint1", "panda_joint2"],
+            urdf_path=urdf_path,
+            srdf_path=srdf_path,
+            urdf_meshes_dir=urdf_meshes_dir,
+            collision_as_capsule=True,
+            self_collision=True,
+            armature=np.linspace(0.1, 0.9, robot.model.nq),
+        )
+
+    def setUp(self):
+        """
+        This method ensures that a fresh RobotModelParameters and RobotModels instance
+        are created for each test case while still benefiting from shared setup computations.
+        """
+        self.params = deepcopy(self.shared_params)
+        self.robot_models = RobotModels(self.params)
+
+    def test_initial_configuration(self):
+        self.assertTrue(np.array_equal(self.robot_models.q0, self.params.q0))
+
+    def test_load_models_populates_models(self):
+        self.robot_models.load_models()
+        self.assertIsNotNone(self.robot_models.full_robot_model)
+        self.assertIsNotNone(self.robot_models.visual_model)
+        self.assertIsNotNone(self.robot_models.collision_model)
+
+    def test_invalid_joint_name_raises_value_error(self):
+        # Modify a fresh instance of parameters for this test
+        self.params.locked_joint_names = ["InvalidJoint"]
+        with self.assertRaises(ValueError):
+            self.robot_models._apply_locked_joints()
+
+    def test_generate_capsule_name(self):
+        name = self.robot_models._generate_capsule_name(
+            "base_link", ["base_link_capsule_0"]
+        )
+        self.assertEqual(name, "base_link_capsule_1")
+
+    def test_armature_property(self):
+        self.assertTrue(
+            np.array_equal(self.robot_models.armature, self.params.armature)
+        )
+
+    def test_collision_pairs(self):
+        """Checking that the collision model has collision pairs."""
+        self.assertTrue(len(self.robot_models.collision_model.collisionPairs) > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -145,7 +145,9 @@ class TestRobotModels(unittest.TestCase):
 
     def test_collision_pairs(self):
         """Checking that the collision model has collision pairs."""
-        self.assertTrue(len(self.robot_models.collision_model.collisionPairs) > 0)
+        self.assertTrue(
+            len(self.robot_models.collision_model.collisionPairs) == 44
+        )  # Number of collision pairs in the panda model
 
     def test_rnea(self):
         """Checking that the RNEA method works."""

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -19,10 +19,11 @@ class TestRobotModelParameters(unittest.TestCase):
         urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
+        locked_joint_names = ["panda_joint1", "panda_joint2"]
         params = RobotModelParameters(
             q0=q0,
             free_flyer=free_flyer,
-            locked_joint_names=["panda_joint1", "panda_joint2"],
+            locked_joint_names=locked_joint_names,
             urdf_path=urdf_path,
             srdf_path=srdf_path,
             urdf_meshes_dir=urdf_meshes_dir,
@@ -52,13 +53,13 @@ class TestRobotModelParameters(unittest.TestCase):
         urdf_path = Path(robot.urdf)
         srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
         urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
-        print(urdf_meshes_dir)
+        locked_joint_names = ["panda_joint1", "panda_joint2"]
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
         params = RobotModelParameters(
             q0=q0,
             free_flyer=free_flyer,
-            locked_joint_names=["panda_joint1", "panda_joint2"],
+            locked_joint_names=locked_joint_names,
             urdf_path=urdf_path,
             srdf_path=srdf_path,
             urdf_meshes_dir=urdf_meshes_dir,
@@ -100,12 +101,12 @@ class TestRobotModels(unittest.TestCase):
         urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
-
+        locked_joint_names = ["panda_joint1", "panda_joint2"]
         # Store shared initial parameters
         cls.shared_params = RobotModelParameters(
             q0=q0,
             free_flyer=free_flyer,
-            locked_joint_names=["panda_joint1", "panda_joint2"],
+            locked_joint_names=locked_joint_names,
             urdf_path=urdf_path,
             srdf_path=srdf_path,
             urdf_meshes_dir=urdf_meshes_dir,

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -90,7 +90,7 @@ class TestRobotModelParameters(unittest.TestCase):
 
 class TestRobotModels(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(self):
         """
         This method sets up the shared environment for all test cases in the class.
         """
@@ -103,7 +103,7 @@ class TestRobotModels(unittest.TestCase):
         q0 = np.zeros(robot.model.nq)
         locked_joint_names = ["panda_joint1", "panda_joint2"]
         # Store shared initial parameters
-        cls.shared_params = RobotModelParameters(
+        self.shared_params = RobotModelParameters(
             q0=q0,
             free_flyer=free_flyer,
             locked_joint_names=locked_joint_names,
@@ -131,6 +131,14 @@ class TestRobotModels(unittest.TestCase):
         self.assertIsNotNone(self.robot_models.full_robot_model)
         self.assertIsNotNone(self.robot_models.visual_model)
         self.assertIsNotNone(self.robot_models.collision_model)
+
+    def test_reduced_robot_model(self):
+        self.robot_models.load_models()
+        self.assertTrue(
+            self.robot_models.robot_model.nq
+            == self.robot_models.full_robot_model.nq
+            - len(self.params.locked_joint_names)
+        )
 
     def test_invalid_joint_name_raises_value_error(self):
         # Modify a fresh instance of parameters for this test

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -14,9 +14,9 @@ class TestRobotModelParameters(unittest.TestCase):
         """Test that the dataclass initializes correctly with valid input."""
 
         robot = robex.load("panda")
-        urdf_path = robot.urdf
-        srdf_path = robot.urdf.replace("urdf", "srdf")
-        urdf_meshes_dir = dirname(dirname(robot.urdf))
+        urdf_path = Path(robot.urdf)
+        srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
+        urdf_meshes_dir = robot.urdf.parent.parent
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
         params = RobotModelParameters(

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -1,0 +1,83 @@
+import unittest
+import numpy as np
+from pathlib import Path
+from os.path import dirname
+import example_robot_data as robex
+
+from agimus_controller.factory.robot_model import RobotModelParameters
+
+
+class TestRobotModelParameters(unittest.TestCase):
+    def test_valid_initialization(self):
+        """Test that the dataclass initializes correctly with valid input."""
+
+        robot = robex.load("panda")
+        urdf_path = Path(robot.urdf)
+        srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
+        urdf_meshes_dir = Path(dirname(dirname(robot.urdf)))
+        q0 = np.array([0.0, 1.0, 2.0])
+        params = RobotModelParameters(
+            q0=q0,
+            free_flyer=True,
+            locked_joint_names=["panda_joint1", "panda_joint2"],
+            urdf_path=urdf_path,
+            srdf_path=srdf_path,
+            urdf_meshes_dir=urdf_meshes_dir,
+            collision_as_capsule=True,
+            self_collision=True,
+            armature=np.array([0.1, 0.2, 0.3]),
+        )
+
+        self.assertTrue(np.array_equal(params.q0, q0))
+        self.assertEqual(params.free_flyer, True)
+        self.assertEqual(params.locked_joint_names, ["panda_joint1", "panda_joint2"])
+        self.assertEqual(params.urdf_path, urdf_path)
+        self.assertEqual(params.srdf_path, srdf_path)
+        self.assertEqual(params.urdf_meshes_dir, urdf_meshes_dir)
+        self.assertTrue(params.collision_as_capsule)
+        self.assertTrue(params.self_collision)
+        self.assertTrue(np.array_equal(params.armature, np.array([0.1, 0.2, 0.3])))
+
+    def test_empty_q0_raises_error(self):
+        """Test that an empty q0 raises a ValueError."""
+        with self.assertRaises(ValueError):
+            RobotModelParameters(q0=np.array([]))
+
+    def test_armature_default_value(self):
+        """Test that the armature is set to default if not provided."""
+        q0 = np.array([0.0, 1.0, 2.0])
+        params = RobotModelParameters(q0=q0)
+        self.assertTrue(np.array_equal(params.armature, np.zeros_like(q0)))
+
+    def test_armature_mismatched_shape_raises_error(self):
+        """Test that a mismatched armature raises a ValueError."""
+        q0 = np.array([0.0, 1.0, 2.0])
+        armature = np.array([0.1, 0.2])  # Wrong shape
+        with self.assertRaises(ValueError):
+            RobotModelParameters(q0=q0, armature=armature)
+
+    def test_invalid_urdf_path_raises_error(self):
+        """Test that an invalid URDF path raises a ValueError."""
+        q0 = np.array([0.0, 1.0, 2.0])
+        with self.assertRaises(ValueError):
+            RobotModelParameters(q0=q0, urdf_path=None)
+
+    def test_invalid_srdf_path_type_raises_error(self):
+        """Test that a non-string SRDF path raises a ValueError."""
+        q0 = np.array([0.0, 1.0, 2.0])
+        with self.assertRaises(ValueError):
+            RobotModelParameters(q0=q0, srdf_path=12345)
+
+    def test_collision_color_default(self):
+        """Test that the default collision color is set correctly."""
+        q0 = np.array([0.0, 1.0, 2.0])
+        params = RobotModelParameters(q0=q0)
+        self.assertTrue(
+            np.array_equal(
+                params.collision_color, np.array([249.0, 136.0, 126.0, 125.0]) / 255.0
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -1,9 +1,10 @@
-from os.path import dirname
-from pathlib import Path
-import unittest
 from copy import deepcopy
+from os.path import dirname
+import unittest
+
 import example_robot_data as robex
 import numpy as np
+import pinocchio as pin
 
 from agimus_controller.factory.robot_model import RobotModelParameters, RobotModels
 
@@ -149,6 +150,14 @@ class TestRobotModels(unittest.TestCase):
     def test_collision_pairs(self):
         """Checking that the collision model has collision pairs."""
         self.assertTrue(len(self.robot_models.collision_model.collisionPairs) > 0)
+
+    def test_rnea(self):
+        """Checking that the RNEA method works."""
+        q = np.zeros(self.robot_models.robot_model.nq)
+        v = np.zeros(self.robot_models.robot_model.nv)
+        a = np.zeros(self.robot_models.robot_model.nv)
+        robot_data = self.robot_models.robot_model.createData()
+        pin.rnea(self.robot_models.robot_model, robot_data, q, v, a)
 
 
 if __name__ == "__main__":

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from os.path import dirname
 import unittest
-
+from pathlib import Path
 import example_robot_data as robex
 import numpy as np
 import pinocchio as pin
@@ -16,7 +16,7 @@ class TestRobotModelParameters(unittest.TestCase):
         robot = robex.load("panda")
         urdf_path = Path(robot.urdf)
         srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
-        urdf_meshes_dir = robot.urdf.parent.parent
+        urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
         params = RobotModelParameters(
@@ -49,9 +49,10 @@ class TestRobotModelParameters(unittest.TestCase):
     def test_armature_default_value(self):
         """Test that the armature is set to default if not provided."""
         robot = robex.load("panda")
-        urdf_path = robot.urdf
-        srdf_path = robot.urdf.replace("urdf", "srdf")
-        urdf_meshes_dir = dirname(dirname(robot.urdf))
+        urdf_path = Path(robot.urdf)
+        srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
+        urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
+        print(urdf_meshes_dir)
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
         params = RobotModelParameters(
@@ -77,13 +78,13 @@ class TestRobotModelParameters(unittest.TestCase):
         """Test that an invalid URDF path raises a ValueError."""
         q0 = np.array([0.0, 1.0, 2.0])
         with self.assertRaises(ValueError):
-            RobotModelParameters(q0=q0, urdf_path="None")
+            RobotModelParameters(q0=q0, urdf_path=Path("invalid_path"))
 
     def test_invalid_srdf_path_type_raises_error(self):
         """Test that a non-string SRDF path raises a ValueError."""
         q0 = np.array([0.0, 1.0, 2.0])
         with self.assertRaises(ValueError):
-            RobotModelParameters(q0=q0, srdf_path=12345)
+            RobotModelParameters(q0=q0, srdf_path=Path("invalid_path"))
 
 
 class TestRobotModels(unittest.TestCase):
@@ -94,9 +95,9 @@ class TestRobotModels(unittest.TestCase):
         """
         # Load the example robot model using example robot data to get the URDF path.
         robot = robex.load("panda")
-        urdf_path = robot.urdf
-        srdf_path = robot.urdf.replace("urdf", "srdf")
-        urdf_meshes_dir = dirname(dirname(dirname(dirname(dirname(robot.urdf)))))
+        urdf_path = Path(robot.urdf)
+        srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
+        urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
         free_flyer = False
         q0 = np.zeros(robot.model.nq)
 
@@ -135,12 +136,6 @@ class TestRobotModels(unittest.TestCase):
         self.params.locked_joint_names = ["InvalidJoint"]
         with self.assertRaises(ValueError):
             self.robot_models._apply_locked_joints()
-
-    def test_generate_capsule_name(self):
-        name = self.robot_models._generate_capsule_name(
-            "base_link", ["base_link_capsule_0"]
-        )
-        self.assertEqual(name, "base_link_capsule_1")
 
     def test_armature_property(self):
         self.assertTrue(

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -1,10 +1,11 @@
-import unittest
-import numpy as np
-from pathlib import Path
 from os.path import dirname
-import example_robot_data as robex
+from pathlib import Path
+import unittest
 
-from agimus_controller.factory.robot_model import RobotModelParameters
+import example_robot_data as robex
+import numpy as np
+
+from agimus_controller.factory.robot_model import RobotModelParameters, RobotModels
 
 
 class TestRobotModelParameters(unittest.TestCase):
@@ -12,10 +13,10 @@ class TestRobotModelParameters(unittest.TestCase):
         """Test that the dataclass initializes correctly with valid input."""
 
         robot = robex.load("panda")
-        urdf_path = Path(robot.urdf)
-        srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
-        urdf_meshes_dir = Path(dirname(dirname(robot.urdf)))
-        q0 = np.array([0.0, 1.0, 2.0])
+        urdf_path = robot.urdf
+        srdf_path = robot.urdf.replace("urdf", "srdf")
+        urdf_meshes_dir = dirname(dirname(robot.urdf))
+        q0 = np.zeros(robot.model.nq)
         params = RobotModelParameters(
             q0=q0,
             free_flyer=True,
@@ -25,7 +26,7 @@ class TestRobotModelParameters(unittest.TestCase):
             urdf_meshes_dir=urdf_meshes_dir,
             collision_as_capsule=True,
             self_collision=True,
-            armature=np.array([0.1, 0.2, 0.3]),
+            armature=np.linspace(0.1, 0.9, 9),
         )
 
         self.assertTrue(np.array_equal(params.q0, q0))
@@ -36,7 +37,7 @@ class TestRobotModelParameters(unittest.TestCase):
         self.assertEqual(params.urdf_meshes_dir, urdf_meshes_dir)
         self.assertTrue(params.collision_as_capsule)
         self.assertTrue(params.self_collision)
-        self.assertTrue(np.array_equal(params.armature, np.array([0.1, 0.2, 0.3])))
+        self.assertTrue(np.array_equal(params.armature, np.linspace(0.1, 0.9, 9)))
 
     def test_empty_q0_raises_error(self):
         """Test that an empty q0 raises a ValueError."""
@@ -77,7 +78,3 @@ class TestRobotModelParameters(unittest.TestCase):
                 params.collision_color, np.array([249.0, 136.0, 126.0, 125.0]) / 255.0
             )
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/agimus_controller/tests/test_robot_models.py
+++ b/agimus_controller/tests/test_robot_models.py
@@ -47,8 +47,22 @@ class TestRobotModelParameters(unittest.TestCase):
 
     def test_armature_default_value(self):
         """Test that the armature is set to default if not provided."""
-        q0 = np.array([0.0, 1.0, 2.0])
-        params = RobotModelParameters(q0=q0)
+        robot = robex.load("panda")
+        urdf_path = robot.urdf
+        srdf_path = robot.urdf.replace("urdf", "srdf")
+        urdf_meshes_dir = dirname(dirname(robot.urdf))
+        free_flyer = False
+        q0 = np.zeros(robot.model.nq)
+        params = RobotModelParameters(
+            q0=q0,
+            free_flyer=free_flyer,
+            locked_joint_names=["panda_joint1", "panda_joint2"],
+            urdf_path=urdf_path,
+            srdf_path=srdf_path,
+            urdf_meshes_dir=urdf_meshes_dir,
+            collision_as_capsule=True,
+            self_collision=True,
+        )
         self.assertTrue(np.array_equal(params.armature, np.zeros_like(q0)))
 
     def test_armature_mismatched_shape_raises_error(self):
@@ -62,23 +76,13 @@ class TestRobotModelParameters(unittest.TestCase):
         """Test that an invalid URDF path raises a ValueError."""
         q0 = np.array([0.0, 1.0, 2.0])
         with self.assertRaises(ValueError):
-            RobotModelParameters(q0=q0, urdf_path=None)
+            RobotModelParameters(q0=q0, urdf_path="None")
 
     def test_invalid_srdf_path_type_raises_error(self):
         """Test that a non-string SRDF path raises a ValueError."""
         q0 = np.array([0.0, 1.0, 2.0])
         with self.assertRaises(ValueError):
             RobotModelParameters(q0=q0, srdf_path=12345)
-
-    def test_collision_color_default(self):
-        """Test that the default collision color is set correctly."""
-        q0 = np.array([0.0, 1.0, 2.0])
-        params = RobotModelParameters(q0=q0)
-        self.assertTrue(
-            np.array_equal(
-                params.collision_color, np.array([249.0, 136.0, 126.0, 125.0]) / 255.0
-            )
-        )
 
 
 class TestRobotModels(unittest.TestCase):


### PR DESCRIPTION
Hello,

in this PR, the refactoring of the robot model factory. This has to be merged before the OCP class PR.

I ditched a lot of stuff to keep the essential: **a robot wrapper with armature**. Please, say if you need / want some other stuff in it.

I decided to get rid of the story of "complete' collision/visual models" because in my opinion it doesn't make much sense. Either it's mesh or simple convex shapes, but there is no reduction. If you're against, again, let's discuss it in the comments. 

There is a function to directly parse the urdf and from sphere cylinder, obtain a collision model with capsules instead of sphere cylinder.

That's about it, it still needs unit testing, i'm working on it right now.


