### PR TITLE
 Fix WarmStartShiftPreviousSolution and add unit test

### DIFF
--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -87,6 +87,10 @@ class RobotModels:
         self.load_models()  # Populate models
 
     @property
+    def params(self) -> RobotModelParameters:
+        return self._params
+
+    @property
     def full_robot_model(self) -> pin.Model:
         """Full robot model."""
         if self._full_robot_model is None:

--- a/agimus_controller/agimus_controller/ocp_base_croco.py
+++ b/agimus_controller/agimus_controller/ocp_base_croco.py
@@ -27,7 +27,7 @@ class OCPBaseCroco(OCPBase):
         # Setting the robot model
         self._robot_models = robot_models
         self._collision_model = self._robot_models.collision_model
-        self._armature = self._robot_models._params.armature
+        self._armature = self._robot_models.params.armature
 
         # Stat and actuation model
         self._state = crocoddyl.StateMultibody(self._robot_models.robot_model)
@@ -76,6 +76,10 @@ class OCPBaseCroco(OCPBase):
     def dt(self) -> float:
         """Integration step of the OCP."""
         return self._ocp_params.dt
+    
+    @property
+    def problem(self) -> crocoddyl.ShootingProblem:
+        return self._problem
 
     @abstractmethod
     def create_running_model_list(self) -> list[crocoddyl.ActionModelAbstract]:

--- a/agimus_controller/agimus_controller/ocp_base_croco.py
+++ b/agimus_controller/agimus_controller/ocp_base_croco.py
@@ -27,7 +27,7 @@ class OCPBaseCroco(OCPBase):
         # Setting the robot model
         self._robot_models = robot_models
         self._collision_model = self._robot_models.collision_model
-        self._armature = self._robot_models.params.armature
+        self._armature = self._robot_models.armature
 
         # Stat and actuation model
         self._state = crocoddyl.StateMultibody(self._robot_models.robot_model)

--- a/agimus_controller/agimus_controller/ocp_base_croco.py
+++ b/agimus_controller/agimus_controller/ocp_base_croco.py
@@ -76,7 +76,7 @@ class OCPBaseCroco(OCPBase):
     def dt(self) -> float:
         """Integration step of the OCP."""
         return self._ocp_params.dt
-    
+
     @property
     def problem(self) -> crocoddyl.ShootingProblem:
         return self._problem

--- a/agimus_controller/agimus_controller/ocp_param_base.py
+++ b/agimus_controller/agimus_controller/ocp_param_base.py
@@ -35,6 +35,6 @@ class OCPParamsBaseCroco:
     @property
     def timesteps(self) -> tuple[float]:
         return sum(
-            ((self.dt*factor,) * number for factor, number in self.dt_factor_n_seq),
+            ((self.dt * factor,) * number for factor, number in self.dt_factor_n_seq),
             tuple(),
         )

--- a/agimus_controller/agimus_controller/ocp_param_base.py
+++ b/agimus_controller/agimus_controller/ocp_param_base.py
@@ -28,6 +28,13 @@ class OCPParamsBaseCroco:
 
     def __post_init__(self):
         assert (
-            self.horizon_size == sum(sn for _, sn in self.dt_factor_n_seq)
+            self.horizon_size == sum(sn for _, sn in self.dt_factor_n_seq) + 1
             and "The horizon size must be equal to the sum of the time steps."
+        )
+
+    @property
+    def timesteps(self) -> tuple[float]:
+        return sum(
+            ((self.dt*factor,) * number for factor, number in self.dt_factor_n_seq),
+            tuple(),
         )

--- a/agimus_controller/agimus_controller/warm_start_shift_previous_solution.py
+++ b/agimus_controller/agimus_controller/warm_start_shift_previous_solution.py
@@ -11,16 +11,15 @@ When there is no previous solution, the warm start is calculated using an intern
 WarmStartReference object.
 """
 
-import typing as T
 import numpy as np
 import numpy.typing as npt
-import pinocchio
 import crocoddyl
 
 from agimus_controller.trajectory import TrajectoryPoint
 from agimus_controller.warm_start_base import WarmStartBase
 from agimus_controller.factory.robot_model import RobotModels
 from agimus_controller.ocp_param_base import OCPParamsBaseCroco
+
 
 class WarmStartShiftPreviousSolution(WarmStartBase):
     """Generate a warm start by shifting in time the solution of the previous OCP iteration"""

--- a/agimus_controller/tests/test_ocp_croco_base.py
+++ b/agimus_controller/tests/test_ocp_croco_base.py
@@ -140,7 +140,7 @@ class TestSimpleOCPCroco(unittest.TestCase):
         self.ocp_params = OCPParamsBaseCroco(
             dt=0.1,
             horizon_size=10,
-            dt_factor_n_seq=[(1, 10)],
+            dt_factor_n_seq=[(1, 9)],
             solver_iters=100,
             callbacks=False,
         )

--- a/agimus_controller/tests/test_ocp_croco_goal_reaching.py
+++ b/agimus_controller/tests/test_ocp_croco_goal_reaching.py
@@ -54,7 +54,7 @@ class TestOCPGoalReaching(unittest.TestCase):
         self._ocp_params = OCPParamsBaseCroco(
             dt=dt,
             horizon_size=horizon_size,
-            dt_factor_n_seq=[(1, horizon_size-1)],
+            dt_factor_n_seq=[(1, horizon_size - 1)],
             solver_iters=solver_iters,
             callbacks=callbacks,
         )

--- a/agimus_controller/tests/test_ocp_croco_goal_reaching.py
+++ b/agimus_controller/tests/test_ocp_croco_goal_reaching.py
@@ -54,7 +54,7 @@ class TestOCPGoalReaching(unittest.TestCase):
         self._ocp_params = OCPParamsBaseCroco(
             dt=dt,
             horizon_size=horizon_size,
-            dt_factor_n_seq=[(1, horizon_size)],
+            dt_factor_n_seq=[(1, horizon_size-1)],
             solver_iters=solver_iters,
             callbacks=callbacks,
         )

--- a/agimus_controller/tests/test_ocp_param_base.py
+++ b/agimus_controller/tests/test_ocp_param_base.py
@@ -18,7 +18,7 @@ class TestOCPParamsCrocoBase(unittest.TestCase):
         params = {
             "dt": 0.01,
             "horizon_size": 100,
-            "dt_factor_n_seq": [(1, 100)],
+            "dt_factor_n_seq": [(1, 99)],
             "solver_iters": 50,
             "qp_iters": 200,
             "termination_tolerance": 1e-3,

--- a/agimus_controller/tests/test_warm_start_shift_previous_reference.py
+++ b/agimus_controller/tests/test_warm_start_shift_previous_reference.py
@@ -52,7 +52,6 @@ class TestWarmStart(unittest.TestCase):
             ws.generate(None, None)
 
     def test_generate(self):
-        dt = 0.1
         ws = WarmStartShiftPreviousSolution()
         ocp_params = OCPParamsBaseCroco(
             dt=0.1,

--- a/agimus_controller/tests/test_warm_start_shift_previous_reference.py
+++ b/agimus_controller/tests/test_warm_start_shift_previous_reference.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 import unittest
-import copy
 
 import numpy as np
 import example_robot_data as robex
-import pinocchio as pin
 
 from agimus_controller.mpc_data import OCPResults
-from agimus_controller.warm_start_shift_previous_solution import WarmStartShiftPreviousSolution
+from agimus_controller.warm_start_shift_previous_solution import (
+    WarmStartShiftPreviousSolution,
+)
 from agimus_controller.trajectory import TrajectoryPoint
 from agimus_controller.factory.robot_model import RobotModels, RobotModelParameters
 from agimus_controller.ocp_param_base import OCPParamsBaseCroco
@@ -50,7 +50,7 @@ class TestWarmStart(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             ws.generate(None, None)
-  
+
     def test_generate(self):
         dt = 0.1
         ws = WarmStartShiftPreviousSolution()
@@ -58,11 +58,14 @@ class TestWarmStart(unittest.TestCase):
             dt=0.1,
             solver_iters=1000,
             horizon_size=4,
-            dt_factor_n_seq=[(1, 2), (2, 1), ],
+            dt_factor_n_seq=[
+                (1, 2),
+                (2, 1),
+            ],
         )
         assert ocp_params.timesteps == (0.1, 0.1, 0.2)
         nu = 3
-        
+
         ws.setup(
             self.robot_models,
             ocp_params,
@@ -70,17 +73,15 @@ class TestWarmStart(unittest.TestCase):
 
         ocp = OCPCrocoGoalReaching(self.robot_models, ocp_params)
         model = self.robot_models.robot_model
-        controls = [
-            np.random.random(model.nv) for _ in range(nu)
-        ]
-        ocp.problem.x0 = np.zeros(model.nq+model.nv)
+        controls = [np.random.random(model.nv) for _ in range(nu)]
+        ocp.problem.x0 = np.zeros(model.nq + model.nv)
         states = ocp.problem.rollout(controls)
         # Sanity check
         for i in range(nu):
             m = ocp.problem.runningModels[i]
             d = ocp.problem.runningDatas[i]
             m.calc(d, states[i], controls[i])
-            np.testing.assert_array_equal(states[i+1], d.xnext)
+            np.testing.assert_array_equal(states[i + 1], d.xnext)
 
         prev_solution = OCPResults(
             states=states.copy(),
@@ -89,10 +90,10 @@ class TestWarmStart(unittest.TestCase):
         )
 
         ws.update_previous_solution(prev_solution)
-        
+
         init_state = TrajectoryPoint(
-            robot_configuration=-10*np.ones(model.nq),
-            robot_velocity=100*np.ones(model.nv)
+            robot_configuration=-10 * np.ones(model.nq),
+            robot_velocity=100 * np.ones(model.nv),
         )
         x0, x_init, u_init = ws.generate(init_state, [])
 
@@ -102,8 +103,8 @@ class TestWarmStart(unittest.TestCase):
         assert len(u_init) == nu
 
         # Check values (assuming `generate` would use these random inputs)
-        np.testing.assert_array_equal(x0[:model.nq], init_state.robot_configuration)
-        np.testing.assert_array_equal(x0[model.nq:], init_state.robot_velocity)
+        np.testing.assert_array_equal(x0[: model.nq], init_state.robot_configuration)
+        np.testing.assert_array_equal(x0[model.nq :], init_state.robot_velocity)
         # Integrate each point and compare to x_init.
         # We skip the first control because this is not in x_init (discarded).
         for i in range(1, nu):
@@ -111,11 +112,12 @@ class TestWarmStart(unittest.TestCase):
             d = ocp.problem.runningDatas[i]
             m.dt = ocp_params.dt
             m.calc(d, states[i], controls[i])
-            
+
             # This assert is not based on something we actually desire.
             # We may want something smarted for the control
-            np.testing.assert_array_equal(u_init[i-1], controls[i])
-            np.testing.assert_array_equal(x_init[i-1], d.xnext)
+            np.testing.assert_array_equal(u_init[i - 1], controls[i])
+            np.testing.assert_array_equal(x_init[i - 1], d.xnext)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/agimus_controller/tests/test_warm_start_shift_previous_reference.py
+++ b/agimus_controller/tests/test_warm_start_shift_previous_reference.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+import unittest
+import copy
+
+import numpy as np
+import example_robot_data as robex
+import pinocchio as pin
+
+from agimus_controller.mpc_data import OCPResults
+from agimus_controller.warm_start_shift_previous_solution import WarmStartShiftPreviousSolution
+from agimus_controller.trajectory import TrajectoryPoint
+from agimus_controller.factory.robot_model import RobotModels, RobotModelParameters
+from agimus_controller.ocp_param_base import OCPParamsBaseCroco
+from agimus_controller.ocp.ocp_croco_goal_reaching import OCPCrocoGoalReaching
+
+
+class TestWarmStart(unittest.TestCase):
+    def setUp(self):
+        ### LOAD ROBOT
+        robot = robex.load("panda")
+        urdf_path = Path(robot.urdf)
+        srdf_path = Path(robot.urdf.replace("urdf", "srdf"))
+        urdf_meshes_dir = urdf_path.parent.parent.parent.parent.parent
+        free_flyer = False
+        locked_joint_names = ["panda_finger_joint1", "panda_finger_joint2"]
+        reduced_nq = robot.model.nq - len(locked_joint_names)
+        moving_joint_names = set(robot.model.names) - set(
+            locked_joint_names + ["universe"]
+        )
+        q0 = np.zeros(robot.model.nq)
+        armature = np.full(reduced_nq, 0.1)
+
+        # Store shared initial parameters
+        self.params = RobotModelParameters(
+            q0=q0,
+            free_flyer=free_flyer,
+            moving_joint_names=moving_joint_names,
+            urdf=urdf_path,
+            srdf=srdf_path,
+            urdf_meshes_dir=urdf_meshes_dir,
+            collision_as_capsule=True,
+            self_collision=False,
+            armature=armature,
+        )
+
+        self.robot_models = RobotModels(self.params)
+
+    def test_initialization(self):
+        ws = WarmStartShiftPreviousSolution()
+
+        with self.assertRaises(AssertionError):
+            ws.generate(None, None)
+  
+    def test_generate(self):
+        dt = 0.1
+        ws = WarmStartShiftPreviousSolution()
+        ocp_params = OCPParamsBaseCroco(
+            dt=0.1,
+            solver_iters=1000,
+            horizon_size=4,
+            dt_factor_n_seq=[(1, 2), (2, 1), ],
+        )
+        assert ocp_params.timesteps == (0.1, 0.1, 0.2)
+        nu = 3
+        
+        ws.setup(
+            self.robot_models,
+            ocp_params,
+        )
+
+        ocp = OCPCrocoGoalReaching(self.robot_models, ocp_params)
+        model = self.robot_models.robot_model
+        controls = [
+            np.random.random(model.nv) for _ in range(nu)
+        ]
+        ocp.problem.x0 = np.zeros(model.nq+model.nv)
+        states = ocp.problem.rollout(controls)
+        # Sanity check
+        for i in range(nu):
+            m = ocp.problem.runningModels[i]
+            d = ocp.problem.runningDatas[i]
+            m.calc(d, states[i], controls[i])
+            np.testing.assert_array_equal(states[i+1], d.xnext)
+
+        prev_solution = OCPResults(
+            states=states.copy(),
+            ricatti_gains=[],
+            feed_forward_terms=controls.copy(),
+        )
+
+        ws.update_previous_solution(prev_solution)
+        
+        init_state = TrajectoryPoint(
+            robot_configuration=-10*np.ones(model.nq),
+            robot_velocity=100*np.ones(model.nv)
+        )
+        x0, x_init, u_init = ws.generate(init_state, [])
+
+        # Assert
+        # Check shapes
+        assert len(x_init) == nu
+        assert len(u_init) == nu
+
+        # Check values (assuming `generate` would use these random inputs)
+        np.testing.assert_array_equal(x0[:model.nq], init_state.robot_configuration)
+        np.testing.assert_array_equal(x0[model.nq:], init_state.robot_velocity)
+        # Integrate each point and compare to x_init.
+        # We skip the first control because this is not in x_init (discarded).
+        for i in range(1, nu):
+            m = ocp.problem.runningModels[i]
+            d = ocp.problem.runningDatas[i]
+            m.dt = ocp_params.dt
+            m.calc(d, states[i], controls[i])
+            
+            # This assert is not based on something we actually desire.
+            # We may want something smarted for the control
+            np.testing.assert_array_equal(u_init[i-1], controls[i])
+            np.testing.assert_array_equal(x_init[i-1], d.xnext)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The previous implementations of WarmStartShiftPreviousSolution was not working for obvious reasons (among which it was not tested).

In this PR, I fix the way points are shifted (which is what @MaximilienNaveau suggested earlier I believe) and I add a unit test for the shifting method.