### PR TITLE
Add a parameter to turn on constant delay with delay compensation

### DIFF
--- a/agimus_controller/agimus_controller/mpc.py
+++ b/agimus_controller/agimus_controller/mpc.py
@@ -1,4 +1,5 @@
 import time
+import numpy.typing as npt
 
 from agimus_controller.mpc_data import OCPResults, MPCDebugData
 from agimus_controller.ocp_base import OCPBase
@@ -62,6 +63,20 @@ class MPC(object):
         self._mpc_debug_data.duration_ocp_solve_ns = timer4 - timer3
 
         return self._ocp.ocp_results
+
+    def integrate(
+        self, state: TrajectoryPoint, control: npt.NDArray
+    ) -> TrajectoryPoint:
+        """Integrate the control starting from state during duration dt.
+
+        Returns:
+            the same TrajectoryPoint object, where robot_configuration and robot_velocity have been modified.
+        """
+        x = self._ocp.integrate(state.robot_state, control)
+        state.time_ns += int(self.ocp.dt * 1e-9)
+        state.robot_configuration = x[: len(state.robot_configuration)]
+        state.robot_velocity = x[len(state.robot_configuration) :]
+        return state
 
     @property
     def mpc_debug_data(self) -> MPCDebugData:

--- a/agimus_controller/agimus_controller/mpc.py
+++ b/agimus_controller/agimus_controller/mpc.py
@@ -73,7 +73,7 @@ class MPC(object):
             the same TrajectoryPoint object, where robot_configuration and robot_velocity have been modified.
         """
         x = self._ocp.integrate(state.robot_state, control)
-        state.time_ns += int(self.ocp.dt * 1e-9)
+        state.time_ns += int(self._ocp.dt * 1e-9)
         state.robot_configuration = x[: len(state.robot_configuration)]
         state.robot_velocity = x[len(state.robot_configuration) :]
         return state

--- a/agimus_controller/agimus_controller/ocp_base.py
+++ b/agimus_controller/agimus_controller/ocp_base.py
@@ -66,6 +66,13 @@ class OCPBase(ABC):
         """
         pass
 
+    @abstractmethod
+    def integrate(
+        self, state: npt.NDArray[np.float64], control: npt.NDArray
+    ) -> npt.NDArray[np.float64]:
+        """Integrate the control starting from state during duration dt."""
+        pass
+
     @property
     @abstractmethod
     def ocp_results(self) -> OCPResults:

--- a/agimus_controller/agimus_controller/ocp_base_croco.py
+++ b/agimus_controller/agimus_controller/ocp_base_croco.py
@@ -137,6 +137,13 @@ class OCPBaseCroco(OCPBase):
             feed_forward_terms=self._solver.us,
         )
 
+    def integrate(
+        self, state: npt.NDArray[np.float64], control: npt.NDArray
+    ) -> npt.NDArray[np.float64]:
+        data = self._problem.runningDatas[0]
+        self._problem.runningModels[0].calc(data, state, control)
+        return data.xnext
+
     @property
     def ocp_results(self) -> OCPResults:
         """Output data structure of the OCP.

--- a/agimus_controller/agimus_controller/trajectory.py
+++ b/agimus_controller/agimus_controller/trajectory.py
@@ -17,6 +17,10 @@ class TrajectoryPoint:
     forces: dict[Force] | None = None  # Dictionary of pinocchio.Force
     end_effector_poses: dict[SE3] | None = None  # Dictionary of pinocchio.SE3
 
+    @property
+    def robot_state(self) -> npt.NDArray[np.float64]:
+        return np.concatenate(self.robot_configuration, self.robot_velocity)
+
     def __eq__(self, other):
         if not isinstance(other, TrajectoryPoint):
             return False
@@ -78,6 +82,10 @@ class TrajectoryPointWeights:
     w_robot_effort: npt.NDArray[np.float64] | None = None
     w_forces: dict[npt.NDArray[np.float64]] | None = None
     w_end_effector_poses: dict[npt.NDArray[np.float64]] | None = None
+
+    @property
+    def w_robot_state(self) -> npt.NDArray[np.float64]:
+        return np.concatenate(self.w_robot_configuration, self.w_robot_velocity)
 
     def __eq__(self, other):
         if not isinstance(other, TrajectoryPointWeights):

--- a/agimus_controller/agimus_controller/trajectory.py
+++ b/agimus_controller/agimus_controller/trajectory.py
@@ -19,7 +19,7 @@ class TrajectoryPoint:
 
     @property
     def robot_state(self) -> npt.NDArray[np.float64]:
-        return np.concatenate(self.robot_configuration, self.robot_velocity)
+        return np.concatenate((self.robot_configuration, self.robot_velocity))
 
     def __eq__(self, other):
         if not isinstance(other, TrajectoryPoint):
@@ -85,7 +85,7 @@ class TrajectoryPointWeights:
 
     @property
     def w_robot_state(self) -> npt.NDArray[np.float64]:
-        return np.concatenate(self.w_robot_configuration, self.w_robot_velocity)
+        return np.concatenate((self.w_robot_configuration, self.w_robot_velocity))
 
     def __eq__(self, other):
         if not isinstance(other, TrajectoryPointWeights):

--- a/agimus_controller/tests/test_mpc_unicycle.py
+++ b/agimus_controller/tests/test_mpc_unicycle.py
@@ -76,6 +76,9 @@ class OCPUnicycle(OCPBase):
             )
         )
 
+    def integrate(self, state, control):
+        return unicycle_integrate(state, control, self.dt)
+
     @property
     def ocp_results(self):
         return self._results

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -58,7 +58,7 @@ class AgimusController(Node):
         self.destroy_joint_sub = False
         # Stores the OCP result to be able to publish it
         # at next iteration, when using a constant delay
-        self._ocp_result = None
+        self._ocp_res = None
 
         self.initialize_ros_attributes()
         self.get_logger().info("Init done")
@@ -286,7 +286,7 @@ class AgimusController(Node):
             x0_traj_point = self.mpc.integrate(x0_traj_point, control)
             # Update np_sensor_msg so that the published message contains the correct initial state
             self.np_sensor_msg.joint_state.position = x0_traj_point.robot_configuration
-            self.np_sensor_msg.joint_state.velocity = x0_traj_point.velocity
+            self.np_sensor_msg.joint_state.velocity = x0_traj_point.robot_velocity
         ocp_res = self.mpc.run(
             initial_state=x0_traj_point,
             # Use x0_traj_point time so that this corresponds to time in the future
@@ -296,7 +296,7 @@ class AgimusController(Node):
         if ocp_res is None:
             return
 
-        if self.constant_delay:
+        if self.params.constant_delay:
             self._ocp_res = ocp_res
         else:
             self.send_control_msg(ocp_res)

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller_parameters.yaml
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller_parameters.yaml
@@ -45,6 +45,10 @@ agimus_controller_params:
     type: bool
     default_value: True
     description: "Wether we publish debug data or not"
+  constant_delay:
+    type: bool
+    default_value: False
+    description: "When True, the OCP result is always published with a delay of dt but OCP uses a delay compensation. When False, the result is published as soon as possible."
   rate:
     type: double
     default_value: 100.0


### PR DESCRIPTION
In this PR, I add parameter `constant_delay` that enables the two following features.
1. It makes the ROS node publish the result of an iteration approximately `dt` seconds after having read the joint sensor message.
2. It compensate for this fixed delay by making the OCP start at state `estimated_next_state = integrate(current_state, control, dt)`

By default, those features are disabled so this should not affect any of the existing demos. I haven't tested it neither on demos nor on the robot. It is based on [the tests I reported on matrix](https://matrix.to/#/!NmNXZnvSHGBlYDmyku:matrix.org/$NnOIXn6pn3USs28A2_eA7yhgTPLNMcmSViwpCa9UxDg?via=matrix.org&via=laas.fr) on Feb 19th, 14:08.