### PR TITLE
Fix error in the key and name of the package name of agimus_controller

### DIFF
--- a/agimus_controller/setup.py
+++ b/agimus_controller/setup.py
@@ -7,7 +7,7 @@ setup(
     name=PACKAGE_NAME,
     version="0.0.0",
     packages=find_packages(exclude=["tests"]),
-    package_dir={"agimus_controller": "agimus_controller"},
+    package_dir={"./agimus_controller": "agimus_controller"},
     package_data={"agimus_controller": ["ocp/*.yaml"]},
     python_requires=REQUIRES_PYTHON,
     install_requires=[


### PR DESCRIPTION
Fixing issue during build:

```
Starting >>> agimus_controller
[4.002s] WARNING:colcon.colcon_ros.task.ament_python.build:Package 'agimus_controller' doesn't explicitly install a marker in the package index (colcon-ros currently does it implicitly but that fallback will be removed in the future)
[4.002s] WARNING:colcon.colcon_ros.task.ament_python.build:Package 'agimus_controller' doesn't explicitly install the 'package.xml' file (colcon-ros currently does it implicitly but that fallback will be removed in the future)
--- stderr: agimus_controller                                                                                                                        
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/colcon_core/executor/__init__.py", line 91, in __call__
    rc = await self.task(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/colcon_core/task/__init__.py", line 93, in __call__
    return await task_method(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/colcon_ros/task/ament_python/build.py", line 102, in build
    return await extension.build(additional_hooks=additional_hooks)
  File "/usr/lib/python3/dist-packages/colcon_core/task/python/build.py", line 145, in build
    temp_symlinks = self._symlinks_in_build(args, setup_py_data)
  File "/usr/lib/python3/dist-packages/colcon_core/task/python/build.py", line 299, in _symlinks_in_build
    raise RuntimeError(
RuntimeError: The package_dir contains a mapping from 'agimus_controller' to 'agimus_controller' which is also a key
---
```