### PR TITLE
Add a node to visualize the states predicted by MPC.

### DIFF
--- a/agimus_controller/agimus_controller/mpc_data.py
+++ b/agimus_controller/agimus_controller/mpc_data.py
@@ -18,7 +18,7 @@ class OCPResults:
 @dataclass
 class OCPDebugData:
     # Debug data
-    result: OCPResults = OCPResults()
+    result: OCPResults = field(default_factory=OCPResults)
     references: list[TrajectoryPoint] = field(default_factory=list)
     residuals: T.Dict[str, T.List[npt.NDArray[np.float64]]] = field(
         default_factory=dict
@@ -33,7 +33,7 @@ class OCPDebugData:
 
 @dataclass
 class MPCDebugData:
-    ocp: OCPDebugData = OCPDebugData()
+    ocp: OCPDebugData = field(default_factory=OCPDebugData)
     # Timers
     duration_iteration_ns: int = 0
     duration_horizon_update_ns: int = 0

--- a/agimus_controller/tests/test_mpc_data.py
+++ b/agimus_controller/tests/test_mpc_data.py
@@ -49,8 +49,7 @@ class TestOCPParamsCrocoBase(unittest.TestCase):
         params = {
             "result": list(),
             "references": list(),
-            "kkt_norms": list(),
-            "collision_distance_residuals": list(),
+            "kkt_norm": list(),
             "problem_solved": False,
         }
         obj = OCPDebugData(**deepcopy(params))
@@ -71,8 +70,7 @@ class TestOCPParamsCrocoBase(unittest.TestCase):
                 **{
                     "result": list(),
                     "references": list(),
-                    "kkt_norms": list(),
-                    "collision_distance_residuals": list(),
+                    "kkt_norm": list(),
                     "problem_solved": False,
                 }
             ),

--- a/agimus_controller/tests/test_warm_start_shift_previous_reference.py
+++ b/agimus_controller/tests/test_warm_start_shift_previous_reference.py
@@ -97,7 +97,7 @@ class TestWarmStart(unittest.TestCase):
 
         # Assert
         # Check shapes
-        self.assertEqual(len(x_init), nu+1)
+        self.assertEqual(len(x_init), nu + 1)
         self.assertEqual(len(u_init), nu)
 
         # Check values (assuming `generate` would use these random inputs)

--- a/agimus_controller/tests/test_warm_start_shift_previous_reference.py
+++ b/agimus_controller/tests/test_warm_start_shift_previous_reference.py
@@ -97,8 +97,8 @@ class TestWarmStart(unittest.TestCase):
 
         # Assert
         # Check shapes
-        assert len(x_init) == nu
-        assert len(u_init) == nu
+        self.assertEqual(len(x_init), nu+1)
+        self.assertEqual(len(u_init), nu)
 
         # Check values (assuming `generate` would use these random inputs)
         np.testing.assert_array_equal(x0[: model.nq], init_state.robot_configuration)
@@ -114,7 +114,7 @@ class TestWarmStart(unittest.TestCase):
             # This assert is not based on something we actually desire.
             # We may want something smarted for the control
             np.testing.assert_array_equal(u_init[i - 1], controls[i])
-            np.testing.assert_array_equal(x_init[i - 1], d.xnext)
+            np.testing.assert_array_equal(x_init[i], d.xnext)
 
 
 if __name__ == "__main__":

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -41,86 +41,37 @@ from agimus_controller.trajectory import TrajectoryBuffer, TrajectoryPoint
 from agimus_controller_ros.agimus_controller_parameters import agimus_controller_params
 
 
-class AgimusController(Node):
-    """Agimus controller's ROS 2 node class."""
 
-    def __init__(self, node_name: str = "agimus_controller_node") -> None:
-        """Get ROS parameters, initialize trajectory buffer and ros attributes."""
-        super().__init__(node_name)
-        self.param_listener = agimus_controller_params.ParamListener(self)
-        self.params = self.param_listener.get_params()
-        self.params.ocp.armature = np.array(self.params.ocp.armature)
-        self.traj_buffer = TrajectoryBuffer(self.params.ocp.dt_factor_n_seq)
-        self.params.collision_pairs = [
-            (
-                self.params.get_entry(collision_pair_name).first,
-                self.params.get_entry(collision_pair_name).second,
-            )
-            for collision_pair_name in self.params.collision_pairs_names
-        ]
-        self.ocp_params = OCPParamsBaseCroco(
-            dt=self.params.ocp.dt,
-            dt_factor_n_seq=self.params.ocp.dt_factor_n_seq,
-            horizon_size=self.params.ocp.horizon_size,
-            solver_iters=self.params.ocp.max_iter,
-            callbacks=self.params.ocp.activate_callback,
-            qp_iters=self.params.ocp.max_qp_iter,
-            use_debug_data=self.params.publish_debug_data,
-        )
-        self.last_point = None
-        self.first_run_done = False
-        self.rmodel = None
-        self.mpc = None
+def get_param_from_node(node: Node, node_name: str, param_name: str) -> ParameterValue:
+    """Returns parameter from a node"""
+    service_name = f"/{node_name}/get_parameters"
+    param_client = node.create_client(GetParameters, service_name)
+    while not param_client.wait_for_service(timeout_sec=1.0):
+        node.get_logger().info(f"Service {service_name} not available, waiting again...")
+    request = GetParameters.Request()
+    request.names = [param_name]
+
+    future = param_client.call_async(request)
+    rclpy.spin_until_future_complete(node, future)
+
+    if future.result() is not None:
+        return future.result().values[0]
+    else:
+        raise ValueError(f"Failed to get parameter {param_name} from node {node_name}")
+
+
+class RobotMixin:
+    def init_ros_robot_creation(self) -> None:
         self.q0 = None
         self.robot_description_msg = None
-        self.np_sensor_msg = None
         self.environment_msg = None
         self.robot_srdf_description_msg = None
-        self.destroy_joint_sub = False
-        # Stores the OCP result to be able to publish it
-        # at next iteration, when using a constant delay
-        self._ocp_res = None
-
-        self.initialize_ros_attributes()
-        self.get_logger().info(
-            f"Init done. Horizon total time is {self.ocp_params.total_time}"
-        )
-
-    def get_param_from_node(self, node_name: str, param_name: str) -> ParameterValue:
-        """Returns parameter from the node"""
-        param_client = self.create_client(GetParameters, f"/{node_name}/get_parameters")
-        while not param_client.wait_for_service(timeout_sec=1.0):
-            self.get_logger().info("Service not available, waiting again...")
-        request = GetParameters.Request()
-        request.names = [param_name]
-
-        future = param_client.call_async(request)
-        rclpy.spin_until_future_complete(self, future)
-
-        if future.result() is not None:
-            return future.result().values[0]
-        else:
-            raise ValueError("Failed to load moving joint names from LFC")
-
-    def initialize_ros_attributes(self) -> None:
-        """Initialize ROS related attributes such as Publishers, Subscribers and Timers"""
-        self.sensor_msg = None
-        self.control_msg = None
 
         # Get moving joint names from LFC
-        self.moving_joint_names = self.get_param_from_node(
+        self.moving_joint_names = get_param_from_node(self,
             "linear_feedback_controller", "moving_joint_names"
         ).string_array_value
 
-        self.state_subscriber = self.create_subscription(
-            Sensor,
-            "sensor",
-            self.sensor_callback,
-            qos_profile=QoSProfile(
-                depth=10,
-                reliability=ReliabilityPolicy.BEST_EFFORT,
-            ),
-        )
         self.subscriber_robot_description = self.create_subscription(
             String,
             "/robot_description",
@@ -151,6 +102,115 @@ class AgimusController(Node):
                 reliability=ReliabilityPolicy.RELIABLE,
             ),
         )
+        self.state_subscriber = self.create_subscription(
+            JointState,
+            "joint_states",
+            self.joint_states_callback,
+            qos_profile=QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+            ),
+        )
+
+    def robot_description_callback(self, msg: String) -> None:
+        """Set robot description xml msg."""
+        self.robot_description_msg = msg
+
+    def environment_description_callback(self, msg: String) -> None:
+        """Set environment description xml msg."""
+        self.environment_msg = msg
+
+    def robot_srdf_description_callback(self, msg: String) -> None:
+        """Set robot srdf description xml msg."""
+        self.robot_srdf_description_msg = msg
+
+    def joint_states_callback(self, joint_states_msg: JointState) -> None:
+        """Set joint state reference."""
+        if (
+            self.robot_description_msg is None
+            or self.environment_msg is None
+            or self.robot_srdf_description_msg is None
+        ):
+            return
+        if self.q0 is None:
+            self.q0 = np.array(joint_states_msg.position)
+            self.destroy_subscription(self.state_subscriber)
+            self.destroy_subscription(self.subscriber_robot_description)
+            self.destroy_subscription(self.subscriber_robot_srdf_description)
+            self.destroy_subscription(self.subscriber_environment_description)
+
+    def ros_robot_ready(self) -> bool:
+        return self.q0 is not None
+
+    def create_robot_models(self, **robot_model_parameters_kwargs) -> None:
+        robot_params = RobotModelParameters(
+            robot_urdf=self.robot_description_msg.data,
+            env_urdf=self.environment_msg.data,
+            srdf=self.robot_srdf_description_msg.data,
+            moving_joint_names=self.moving_joint_names,
+            **robot_model_parameters_kwargs
+        )
+        self.robot_models = RobotModels(robot_params)
+        self.rmodel = self.robot_models._robot_model
+
+        self.get_logger().info("Robot Models initialized")
+
+class AgimusController(Node, RobotMixin):
+    """Agimus controller's ROS 2 node class."""
+
+    def __init__(self, node_name: str = "agimus_controller_node") -> None:
+        """Get ROS parameters, initialize trajectory buffer and ros attributes."""
+        super().__init__(node_name)
+        self.param_listener = agimus_controller_params.ParamListener(self)
+        self.params = self.param_listener.get_params()
+        self.params.ocp.armature = np.array(self.params.ocp.armature)
+        self.traj_buffer = TrajectoryBuffer(self.params.ocp.dt_factor_n_seq)
+        self.params.collision_pairs = [
+            (
+                self.params.get_entry(collision_pair_name).first,
+                self.params.get_entry(collision_pair_name).second,
+            )
+            for collision_pair_name in self.params.collision_pairs_names
+        ]
+        self.ocp_params = OCPParamsBaseCroco(
+            dt=self.params.ocp.dt,
+            dt_factor_n_seq=self.params.ocp.dt_factor_n_seq,
+            horizon_size=self.params.ocp.horizon_size,
+            solver_iters=self.params.ocp.max_iter,
+            callbacks=self.params.ocp.activate_callback,
+            qp_iters=self.params.ocp.max_qp_iter,
+            use_debug_data=self.params.publish_debug_data,
+        )
+        self.last_point = None
+        self.first_run_done = False
+        self.rmodel = None
+        self.mpc = None
+        self.np_sensor_msg = None
+        # Stores the OCP result to be able to publish it
+        # at next iteration, when using a constant delay
+        self._ocp_res = None
+
+        self.initialize_ros_attributes()
+        self.get_logger().info(
+            f"Init done. Horizon total time is {self.ocp_params.total_time}"
+        )
+
+    def initialize_ros_attributes(self) -> None:
+        """Initialize ROS related attributes such as Publishers, Subscribers and Timers"""
+        self.sensor_msg = None
+        self.control_msg = None
+
+        self.init_ros_robot_creation()
+
+        self.sensor_subscriber = self.create_subscription(
+            Sensor,
+            "sensor",
+            self.sensor_callback,
+            qos_profile=QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+            ),
+        )
         self.subscriber_mpc_input = self.create_subscription(
             MpcInput,
             "mpc_input",
@@ -163,15 +223,6 @@ class AgimusController(Node):
         self.control_publisher = self.create_publisher(
             Control,
             "control",
-            qos_profile=QoSProfile(
-                depth=10,
-                reliability=ReliabilityPolicy.BEST_EFFORT,
-            ),
-        )
-        self.state_subscriber = self.create_subscription(
-            JointState,
-            "joint_states",
-            self.joint_states_callback,
             qos_profile=QoSProfile(
                 depth=10,
                 reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -241,18 +292,6 @@ class AgimusController(Node):
         """Update the sensor_msg attribute of the class."""
         self.sensor_msg = sensor_msg
 
-    def joint_states_callback(self, joint_states_msg: JointState) -> None:
-        """Set joint state reference."""
-        if (
-            self.robot_description_msg is None
-            or self.environment_msg is None
-            or self.robot_srdf_description_msg is None
-        ):
-            return
-        if self.q0 is None:
-            self.q0 = np.array(joint_states_msg.position)
-            self.destroy_subscription(self.state_subscriber)
-
     def mpc_input_callback(self, msg: MpcInput) -> None:
         """Fill the new point msg in the trajectory buffer."""
         w_traj_point = mpc_msg_to_weighted_traj_point(
@@ -261,35 +300,6 @@ class AgimusController(Node):
         self.traj_buffer.append(w_traj_point)
         self.params.ocp.effector_frame_name = msg.ee_frame_name
         self.effector_frame_name = msg.ee_frame_name
-
-    def robot_description_callback(self, msg: String) -> None:
-        """Set robot description xml msg."""
-        self.robot_description_msg = msg
-
-    def environment_description_callback(self, msg: String) -> None:
-        """Set environment description xml msg."""
-        self.environment_msg = msg
-
-    def robot_srdf_description_callback(self, msg: String) -> None:
-        """Set robot srdf description xml msg."""
-        self.robot_srdf_description_msg = msg
-
-    def create_robot_models(self) -> None:
-        params = RobotModelParameters(
-            robot_urdf=self.robot_description_msg.data,
-            env_urdf=self.environment_msg.data,
-            srdf=self.robot_srdf_description_msg.data,
-            free_flyer=self.params.free_flyer,
-            collision_as_capsule=self.params.collision_as_capsule,
-            self_collision=self.params.self_collision,
-            armature=self.params.ocp.armature,
-            moving_joint_names=self.moving_joint_names,
-            collision_pairs=self.params.collision_pairs,
-        )
-        self.robot_models = RobotModels(params)
-        self.rmodel = self.robot_models._robot_model
-
-        self.get_logger().info("Robot Models initialized")
 
     def buffer_has_enough_data(self, ratio: float) -> bool:
         """
@@ -319,7 +329,7 @@ class AgimusController(Node):
             )
             return
 
-        if self.q0 is None:
+        if not self.ros_robot_ready():
             self.get_logger().warn(
                 "Waiting for robot descriptions...",
                 throttle_duration_sec=5.0,
@@ -336,8 +346,13 @@ class AgimusController(Node):
 
         # Stop the initialization loop.
         self.destroy_timer(self._init_timer)
-
-        self.create_robot_models()
+        self.create_robot_models(
+            free_flyer=self.params.free_flyer,
+            collision_as_capsule=self.params.collision_as_capsule,
+            self_collision=self.params.self_collision,
+            armature=self.params.ocp.armature,
+            collision_pairs=self.params.collision_pairs,
+        )
         self.setup_mpc()
 
         self.get_logger().info(

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -41,26 +41,31 @@ from agimus_controller.trajectory import TrajectoryBuffer, TrajectoryPoint
 from agimus_controller_ros.agimus_controller_parameters import agimus_controller_params
 
 
-
-def get_param_from_node(node: Node, node_name: str, param_name: str) -> ParameterValue:
+def get_param_from_node(
+    requester_node: Node, target_node_name: str, target_param_name: str
+) -> ParameterValue:
     """Returns parameter from a node"""
-    service_name = f"/{node_name}/get_parameters"
-    param_client = node.create_client(GetParameters, service_name)
+    service_name = f"/{target_node_name}/get_parameters"
+    param_client = requester_node.create_client(GetParameters, service_name)
     while not param_client.wait_for_service(timeout_sec=1.0):
-        node.get_logger().info(f"Service {service_name} not available, waiting again...")
+        requester_node.get_logger().info(
+            f"Service {service_name} not available, waiting again..."
+        )
     request = GetParameters.Request()
-    request.names = [param_name]
+    request.names = [target_param_name]
 
     future = param_client.call_async(request)
-    rclpy.spin_until_future_complete(node, future)
+    rclpy.spin_until_future_complete(requester_node, future)
 
     if future.result() is not None:
         return future.result().values[0]
     else:
-        raise ValueError(f"Failed to get parameter {param_name} from node {node_name}")
+        raise ValueError(
+            f"Failed to get parameter {target_param_name} from node {target_node_name}"
+        )
 
 
-class RobotMixin:
+class RobotModelsMixin:
     def init_ros_robot_creation(self) -> None:
         self.q0 = None
         self.robot_description_msg = None
@@ -68,8 +73,8 @@ class RobotMixin:
         self.robot_srdf_description_msg = None
 
         # Get moving joint names from LFC
-        self.moving_joint_names = get_param_from_node(self,
-            "linear_feedback_controller", "moving_joint_names"
+        self.moving_joint_names = get_param_from_node(
+            self, "linear_feedback_controller", "moving_joint_names"
         ).string_array_value
 
         self.subscriber_robot_description = self.create_subscription(
@@ -148,14 +153,15 @@ class RobotMixin:
             env_urdf=self.environment_msg.data,
             srdf=self.robot_srdf_description_msg.data,
             moving_joint_names=self.moving_joint_names,
-            **robot_model_parameters_kwargs
+            **robot_model_parameters_kwargs,
         )
         self.robot_models = RobotModels(robot_params)
         self.rmodel = self.robot_models._robot_model
 
         self.get_logger().info("Robot Models initialized")
 
-class AgimusController(Node, RobotMixin):
+
+class AgimusController(Node, RobotModelsMixin):
     """Agimus controller's ROS 2 node class."""
 
     def __init__(self, node_name: str = "agimus_controller_node") -> None:

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -3,7 +3,7 @@ import rclpy.duration
 import sys
 import argparse
 from rclpy.node import Node
-from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.qos import QoSProfile, ReliabilityPolicy
 
 import rclpy.time
 from builtin_interfaces.msg import Duration as DurationMsg
@@ -11,19 +11,17 @@ from visualization_msgs.msg import MarkerArray, Marker
 from geometry_msgs.msg import Pose
 from agimus_msgs.msg import MpcDebug
 
-from agimus_controller_ros.agimus_controller import RobotMixin, get_param_from_node
+from agimus_controller_ros.agimus_controller import (
+    RobotModelsMixin,
+    get_param_from_node,
+)
 from linear_feedback_controller_msgs_py.numpy_conversions import matrix_msg_to_numpy
 import pinocchio
 import eigenpy
 
 
-default_qos_profile = QoSProfile(
-    depth=10,
-    reliability=ReliabilityPolicy.RELIABLE,
-)
-
-
 def pinocchio_se3_to_geometry_msg_pose(M: pinocchio.SE3, pose: Pose) -> Pose:
+    "Store in `pose` message the transform `M`"
     pose.position.x = M.translation[0]
     pose.position.y = M.translation[1]
     pose.position.z = M.translation[2]
@@ -36,7 +34,12 @@ def pinocchio_se3_to_geometry_msg_pose(M: pinocchio.SE3, pose: Pose) -> Pose:
     return pose
 
 
-class MPCDebuggerNode(Node, RobotMixin):
+class MPCDebuggerNode(Node, RobotModelsMixin):
+    """ROS node class to assist users of the AgimusController ROS node.
+
+    Features:
+    - publishes the current MPC prediction as markers that can be viewed in RViz.
+    """
 
     def __init__(
         self,
@@ -45,6 +48,13 @@ class MPCDebuggerNode(Node, RobotMixin):
         marker_namespace: str,
         marker_size: float,
     ):
+        """
+        Args:
+        - frame_name: name of the frame in the pinocchio Model
+        - parent_frame_name: string passed to field `marker.header.frame_id` in the published messages.
+        - marker_namespace: set the `marker.ns` field.
+        - marker_size: set the `marker.scale` field.
+        """
         super().__init__("mpc_debugger_node")
         self._frame_name = frame_name
         self._parent_frame_name = parent_frame_name
@@ -69,13 +79,7 @@ class MPCDebuggerNode(Node, RobotMixin):
         self.destroy_timer(self._init_timer)
 
         self.get_logger().info("create robot...")
-        self.create_robot_models(
-            free_flyer=self._robot_has_free_flyer,
-            # collision_as_capsule=self.params.collision_as_capsule,
-            # self_collision=self.params.self_collision,
-            # armature=self.params.ocp.armature,
-            # collision_pairs=self.params.collision_pairs,
-        )
+        self.create_robot_models(free_flyer=self._robot_has_free_flyer)
         frame_name_ok = self.rmodel.existFrame(self._frame_name)
         assert frame_name_ok, f"Frame {self._frame_name} could not be found."
         self.rdata = self.rmodel.createData()
@@ -85,7 +89,7 @@ class MPCDebuggerNode(Node, RobotMixin):
         self._mpc_debug_sub = self.create_subscription(
             MpcDebug,
             "mpc_debug",
-            self.mpc_debug_callback,
+            self.mpc_debug_to_prediction_markers,
             qos_profile=QoSProfile(
                 depth=10,
                 reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -107,7 +111,9 @@ class MPCDebuggerNode(Node, RobotMixin):
         for i, state in enumerate(states):
             marker = Marker()
             marker.header.frame_id = self._parent_frame_name
-            # marker.header.stamp = rclcpp::Clock().now();
+            # The MPC debug message does not have a stamp so
+            # it is not possible to correctly set
+            # marker.header.stamp
             marker.ns = self._marker_ns
             marker.id = i
 
@@ -128,7 +134,7 @@ class MPCDebuggerNode(Node, RobotMixin):
             marker.lifetime = DurationMsg(sec=1)
             self._marker_array.markers.append(marker)
 
-    def mpc_debug_callback(self, msg: MpcDebug):
+    def mpc_debug_to_prediction_markers(self, msg: MpcDebug):
         if len(self._marker_array.markers) == 0:
             self._init_marker_array(msg)
 
@@ -147,10 +153,27 @@ def main(args=None):
         "mpc_debugger_node",
         description="This node transforms the MPC debug data into a marker array that can be visualized in RViz.",
     )
-    parser.add_argument("--frame", type=str, required=True)
-    parser.add_argument("--parent-frame", type=str, default="world")
-    parser.add_argument("--marker-size", type=float, default=0.01)
-    parser.add_argument("--marker-ns", type=str, default="states_predictions")
+    parser.add_argument(
+        "--frame",
+        type=str,
+        required=True,
+        help="name of the frame in the pinocchio Model",
+    )
+    parser.add_argument(
+        "--parent-frame",
+        type=str,
+        default="world",
+        help="string passed to field `marker.header.frame_id` in the published messages.",
+    )
+    parser.add_argument(
+        "--marker-size", type=float, default=0.01, help="set the `marker.ns` field."
+    )
+    parser.add_argument(
+        "--marker-ns",
+        type=str,
+        default="states_predictions",
+        help="set the `marker.scale` field.",
+    )
     arguments = parser.parse_args(args)
 
     rclpy.init(args=args)

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -1,0 +1,175 @@
+import rclpy
+import rclpy.duration
+import sys
+import argparse
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+
+import rclpy.time
+from builtin_interfaces.msg import Duration as DurationMsg
+from visualization_msgs.msg import MarkerArray, Marker
+from geometry_msgs.msg import Pose
+from agimus_msgs.msg import MpcDebug
+
+from agimus_controller_ros.agimus_controller import RobotMixin, get_param_from_node
+from linear_feedback_controller_msgs_py.numpy_conversions import matrix_msg_to_numpy
+import pinocchio
+import eigenpy
+
+
+default_qos_profile = QoSProfile(
+    depth=10,
+    reliability=ReliabilityPolicy.RELIABLE,
+)
+
+
+def pinocchio_se3_to_geometry_msg_pose(M: pinocchio.SE3, pose: Pose) -> Pose:
+    pose.position.x = M.translation[0]
+    pose.position.y = M.translation[1]
+    pose.position.z = M.translation[2]
+
+    q = eigenpy.Quaternion(M.rotation)
+    pose.orientation.x = q.x
+    pose.orientation.y = q.y
+    pose.orientation.z = q.z
+    pose.orientation.w = q.w
+    return pose
+
+
+class MPCDebuggerNode(Node, RobotMixin):
+
+    def __init__(
+        self,
+        frame_name: str,
+        parent_frame_name: str,
+        marker_namespace: str,
+        marker_size: float,
+    ):
+        super().__init__("mpc_debugger_node")
+        self._frame_name = frame_name
+        self._parent_frame_name = parent_frame_name
+        self._marker_size = marker_size
+        self._marker_ns = marker_namespace
+
+        self.init_ros_robot_creation()
+        mpc_node_name = "agimus_controller_node"
+        self._robot_has_free_flyer = get_param_from_node(
+            self, mpc_node_name, "free_flyer"
+        ).bool_value
+        self._init_timer = self.create_timer(0.1, self.initialization_callback)
+
+    def initialization_callback(self):
+        if not self.ros_robot_ready():
+            self.get_logger().warn(
+                "Waiting for robot descriptions...",
+                throttle_duration_sec=5.0,
+            )
+            return
+
+        self.destroy_timer(self._init_timer)
+
+        self.get_logger().info("create robot...")
+        self.create_robot_models(
+            free_flyer=self._robot_has_free_flyer,
+            # collision_as_capsule=self.params.collision_as_capsule,
+            # self_collision=self.params.self_collision,
+            # armature=self.params.ocp.armature,
+            # collision_pairs=self.params.collision_pairs,
+        )
+        frame_name_ok = self.rmodel.existFrame(self._frame_name)
+        assert frame_name_ok, f"Frame {self._frame_name} could not be found."
+        self.rdata = self.rmodel.createData()
+        self._fid = self.rmodel.getFrameId(self._frame_name)
+
+        self._marker_array = MarkerArray()
+        self._mpc_debug_sub = self.create_subscription(
+            MpcDebug,
+            "mpc_debug",
+            self.mpc_debug_callback,
+            qos_profile=QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+            ),
+        )
+        self._mpc_markers_pub = self.create_publisher(
+            MarkerArray,
+            "mpc_states_prediction_markers",
+            qos_profile=QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.RELIABLE,
+            ),
+        )
+        self.get_logger().info("init done")
+
+    def _init_marker_array(self, msg: MpcDebug):
+        states = matrix_msg_to_numpy(msg.states_predictions)
+        n = states.shape[0]
+        for i, state in enumerate(states):
+            marker = Marker()
+            marker.header.frame_id = self._parent_frame_name
+            # marker.header.stamp = rclcpp::Clock().now();
+            marker.ns = self._marker_ns
+            marker.id = i
+
+            marker.type = Marker.SPHERE
+
+            marker.action = Marker.ADD
+
+            marker.scale.x = self._marker_size
+            marker.scale.y = self._marker_size
+            marker.scale.z = self._marker_size
+
+            # From red to green, with a increasing transparency.
+            marker.color.r = (n - 1 - i) / (n - 1)
+            marker.color.g = (i + 1) / (n - 1)
+            marker.color.b = 0.0
+            marker.color.a = 0.2 + 0.8 * (n - 1 - i) / (n - 1)
+
+            marker.lifetime = DurationMsg(sec=1)
+            self._marker_array.markers.append(marker)
+
+    def mpc_debug_callback(self, msg: MpcDebug):
+        if len(self._marker_array.markers) == 0:
+            self._init_marker_array(msg)
+
+        states = matrix_msg_to_numpy(msg.states_predictions)
+        nq = self.rmodel.nq
+        for state, marker in zip(states, self._marker_array.markers):
+            pinocchio.forwardKinematics(self.rmodel, self.rdata, state[:nq])
+            M = pinocchio.updateFramePlacement(self.rmodel, self.rdata, self._fid)
+            pinocchio_se3_to_geometry_msg_pose(M, marker.pose)
+
+        self._mpc_markers_pub.publish(self._marker_array)
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        "mpc_debugger_node",
+        description="This node transforms the MPC debug data into a marker array that can be visualized in RViz.",
+    )
+    parser.add_argument("--frame", type=str, required=True)
+    parser.add_argument("--parent-frame", type=str, default="world")
+    parser.add_argument("--marker-size", type=float, default=0.01)
+    parser.add_argument("--marker-ns", type=str, default="states_predictions")
+    arguments = parser.parse_args(args)
+
+    rclpy.init(args=args)
+
+    node = MPCDebuggerNode(
+        frame_name=arguments.frame,
+        parent_frame_name=arguments.parent_frame,
+        marker_namespace=arguments.marker_ns,
+        marker_size=arguments.marker_size,
+    )
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/agimus_controller_ros/setup.py
+++ b/agimus_controller_ros/setup.py
@@ -49,6 +49,7 @@ setup(
         "console_scripts": [
             "simple_trajectory_publisher = agimus_controller_ros.simple_trajectory_publisher:main",
             "agimus_controller_node = agimus_controller_ros.agimus_controller:main",
+            "mpc_debugger_node = agimus_controller_ros.mpc_debugger_node:main",
         ],
     },
     tests_require=["pytest"],


### PR DESCRIPTION
After having started a demo (and made sure that `agimus_controller_node` has `publish_debug_data` set to `True`), with e.g.
```bash
ros2 launch agimus_demo_03_mpc_dummy_traj bringup.launch.py use_gazebo:=true gz_headless:=true ocp:=custom_with_collision_avoidance use_rviz:=true
```
one can launch the conversion node with
```bash
ros2 run agimus_controller_ros mpc_debugger_node --frame fer_hand_tcp
```
Then, in RViz, you can add visualization for topic `mpc_states_prediction_markers`.

The result looks like
![Screenshot from 2025-03-21 15-38-20](https://github.com/user-attachments/assets/e65f2493-026e-465b-9d04-34736f1687ed)


[PR in agimus-demos](https://github.com/agimus-project/agimus-demos/pull/82) that adds, among other, a disabled visualization for the predictions.