### PR TITLE
Add more debug print on collision pair loading failures.

### DIFF
--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -309,9 +309,6 @@ class RobotModels:
             try:
                 geom1_id = self.collision_model.getGeometryId(geom1_name)
                 geom2_id = self.collision_model.getGeometryId(geom2_name)
-                if geom1_id == geom2_id:
-                    print()
-
                 self.collision_model.addCollisionPair(
                     pin.CollisionPair(geom1_id, geom2_id)
                 )

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -305,19 +305,21 @@ class RobotModels:
 
     def _add_collision_pairs(self) -> None:
         """Add collision pairs to the collision model."""
-
-        for collision_pair in self._params.collision_pairs:
+        for geom1_name, geom2_name in self._params.collision_pairs:
             try:
-                geom1_name = collision_pair[0]
-                geom2_name = collision_pair[1]
                 geom1_id = self.collision_model.getGeometryId(geom1_name)
                 geom2_id = self.collision_model.getGeometryId(geom2_name)
+                if geom1_id == geom2_id:
+                    print()
+
                 self.collision_model.addCollisionPair(
                     pin.CollisionPair(geom1_id, geom2_id)
                 )
             except Exception as e:
                 raise ValueError(
-                    f"Invalid collision pair with names {geom1_name} {geom2_name} got error : {e}"
+                    f"Invalid collision pair with names {geom1_name} {geom2_name} "
+                    f"and ids {geom1_id} {geom2_id} in collision_model:\n"
+                    f"{self.collision_model}\ngot error : {e}"                    
                 )
 
     def _generate_capsule_name(self, base_name: str, existing_names: list[str]) -> str:

--- a/agimus_controller/agimus_controller/factory/robot_model.py
+++ b/agimus_controller/agimus_controller/factory/robot_model.py
@@ -319,7 +319,7 @@ class RobotModels:
                 raise ValueError(
                     f"Invalid collision pair with names {geom1_name} {geom2_name} "
                     f"and ids {geom1_id} {geom2_id} in collision_model:\n"
-                    f"{self.collision_model}\ngot error : {e}"                    
+                    f"{self.collision_model}\ngot error : {e}"
                 )
 
     def _generate_capsule_name(self, base_name: str, existing_names: list[str]) -> str:


### PR DESCRIPTION
Small PR that helps debugging the collison pairs loaded from the yaml.
I pring the paris ids and the collision model in addition to the pair names and the error flagged by Pinocchio.