### PR TITLE
Improve MPC debugger and fix TF usage in agimus controller node.

### DIFF
--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -278,18 +278,16 @@ class AgimusController(Node, RobotModelsMixin):
         if yaml_file == "":
             yaml_file = OCPCrocoGeneric.get_default_yaml_file("ocp_goal_reaching.yaml")
         self.get_logger().info(f"Loading OCP definition file {yaml_file}")
-        ocp = OCPCrocoGeneric(self.robot_models, self.ocp_params, yaml_file)
-        self.ocp = ocp
+        self.ocp = OCPCrocoGeneric(self.robot_models, self.ocp_params, yaml_file)
 
-        if len(ocp.input_transforms) > 0:
+        if len(self.ocp.input_transforms) > 0:
             self.initialize_tf_listener()
 
-        ws_shift = WarmStartShiftPreviousSolution()
-        self._ws_shift = ws_shift
-        ws_shift.setup(self.robot_models, self.ocp_params)
+        self._ws_shift = WarmStartShiftPreviousSolution()
+        self._ws_shift.setup(self.robot_models, self.ocp_params)
 
         self.mpc = MPC()
-        self.mpc.setup(ocp=ocp, warm_start=self._ws_shift, buffer=self.traj_buffer)
+        self.mpc.setup(ocp=self.ocp, warm_start=self._ws_shift, buffer=self.traj_buffer)
 
     def setup_mpc_initial_guess(self):
         # Use WarmStartReference for initialization

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -281,13 +281,17 @@ class AgimusController(Node, RobotModelsMixin):
         ocp = OCPCrocoGeneric(self.robot_models, self.ocp_params, yaml_file)
         self.ocp = ocp
 
-        update_transforms = len(ocp.input_transforms) > 0
-        if update_transforms:
+        if len(ocp.input_transforms) > 0:
             self.initialize_tf_listener()
 
         ws_shift = WarmStartShiftPreviousSolution()
+        self._ws_shift = ws_shift
         ws_shift.setup(self.robot_models, self.ocp_params)
 
+        self.mpc = MPC()
+        self.mpc.setup(ocp=ocp, warm_start=self._ws_shift, buffer=self.traj_buffer)
+
+    def setup_mpc_initial_guess(self):
         # Use WarmStartReference for initialization
         ws_ref = WarmStartReference()
         ws_ref.setup(self.robot_models._robot_model)
@@ -300,18 +304,16 @@ class AgimusController(Node, RobotModelsMixin):
             robot_acceleration=np.zeros_like(np_sensor_msg.joint_state.velocity),
         )
         reference_trajectory = self.traj_buffer.horizon
-        if update_transforms:
-            # TODO given that we just created the listener, we might need to wait a bit for the transform to be available.
+        if len(self.ocp.input_transforms) > 0:
+            # We assume that TF buffer has been given enough time between setup_mpc and setup_mpc_initial_guess
+            # for the transforms to be available.
             self.update_transforms()
-        ocp.set_reference_weighted_trajectory(reference_trajectory)
+        self.ocp.set_reference_weighted_trajectory(reference_trajectory)
 
         reference_trajectory_points = [el.point for el in reference_trajectory]
         x0, x_init, u_init = ws_ref.generate(initial_state, reference_trajectory_points)
-        ocp.solve(x0, x_init, u_init, use_iteration_limits_and_timeout=False)
-        ws_shift.update_previous_solution(ocp.ocp_results)
-
-        self.mpc = MPC()
-        self.mpc.setup(ocp=ocp, warm_start=ws_shift, buffer=self.traj_buffer)
+        self.ocp.solve(x0, x_init, u_init, use_iteration_limits_and_timeout=False)
+        self._ws_shift.update_previous_solution(self.ocp.ocp_results)
 
     def sensor_callback(self, sensor_msg: Sensor) -> None:
         """Update the sensor_msg attribute of the class."""
@@ -361,6 +363,19 @@ class AgimusController(Node, RobotModelsMixin):
             )
             return
 
+        if self.mpc is None:
+            self.create_robot_models(
+                free_flyer=self.params.free_flyer,
+                collision_as_capsule=self.params.collision_as_capsule,
+                self_collision=self.params.self_collision,
+                armature=self.params.ocp.armature,
+                collision_pairs=self.params.collision_pairs,
+            )
+            self.setup_mpc()
+            # It is necessary to return, even if the reference buffer has enough data.
+            # This gives some time to fill TF buffer.
+            return
+
         # Wait for enough data in buffer
         if not self.buffer_has_enough_data(2):
             self.get_logger().warn(
@@ -371,14 +386,7 @@ class AgimusController(Node, RobotModelsMixin):
 
         # Stop the initialization loop.
         self.destroy_timer(self._init_timer)
-        self.create_robot_models(
-            free_flyer=self.params.free_flyer,
-            collision_as_capsule=self.params.collision_as_capsule,
-            self_collision=self.params.self_collision,
-            armature=self.params.ocp.armature,
-            collision_pairs=self.params.collision_pairs,
-        )
-        self.setup_mpc()
+        self.setup_mpc_initial_guess()
 
         self.get_logger().info(
             "MPC is initialized and buffer has enough data. Starting to compute controls."

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -216,6 +216,11 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         )
         self._capsules_markers_pub.publish(self._capsule_markers)
 
+    def _ocp_node_models(self):
+        return itertools.chain(
+            self._ocp._problem.runningModels, [self._ocp._problem.terminalModel]
+        )
+
     def _ocp_node_datas(self):
         return itertools.chain(
             self._ocp._problem.runningDatas, [self._ocp._problem.terminalData]
@@ -246,21 +251,31 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
 
         cost_keys = {}
         self._ocp_cost_idx = []
+        ocp_ndof = 0
+
         for data in self._ocp_node_datas():
             idx = []
+            node_ndof = None
             for cost_item in data.differential.costs.costs:
                 name = cost_item.key()
-                if name not in cost_keys:
-                    cost_keys[name] = len(cost_keys)
-                idx.append(cost_keys[name])
+                idx.append(cost_keys.setdefault(name, len(cost_keys)))
+                cost_data = cost_item.data()
+                if node_ndof is None:
+                    node_ndof = cost_data.Lx.shape[0] + cost_data.Lu.shape[0]
+                else:
+                    assert node_ndof == cost_data.Lx.shape[0] + cost_data.Lu.shape[0]
+            ocp_ndof += node_ndof
 
             self._ocp_cost_idx.append(idx)
 
-        self._ocp_cost_keys = dict(map(reversed, cost_keys.items()))
-        self._ocp_cost_data = np.empty(
-            (self._ocp._problem.T + 1, len(cost_keys)), np.float64
+        self._ocp_cost_keys = sorted(cost_keys.keys(), key=cost_keys.__getitem__)
+        self._ocp_cost_value = np.empty(
+            (len(cost_keys), self._ocp._problem.T + 1), np.float64
         )
-        self._ocp_cost_data[:] = np.nan
+        self._ocp_cost_value[:] = np.nan
+
+        self._ocp_cost_jacobian = np.empty((len(cost_keys), ocp_ndof), np.float64)
+        self._ocp_cost_jacobian[:] = 0.0
 
     def _evaluate_ocp(
         self, states: npt.NDArray[np.float64], controls: npt.NDArray[np.float64]
@@ -291,38 +306,83 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         u = [np.asarray(control) for control in controls]
         problem = self._ocp._problem
         problem.calc(x, u)
+        problem.calcDiff(x, u)
 
         # Step 3: retrieve the individual cost items.
+        idof = 0
         with self._mpl_lock:
-            for r, (cost_idx, data) in enumerate(
-                zip(self._ocp_cost_idx, self._ocp_node_datas())
+            for c, (cost_idx, model, data) in enumerate(
+                zip(self._ocp_cost_idx, self._ocp_node_models(), self._ocp_node_datas())
             ):
-                for c, cost_item in zip(cost_idx, data.differential.costs.costs):
-                    self._ocp_cost_data[r, c] = cost_item.data().cost
+                for r, cost_model, cost_data in zip(
+                    cost_idx,
+                    model.differential.costs.costs,
+                    data.differential.costs.costs,
+                ):
+                    d = cost_data.data()
+                    w = cost_model.data().weight
+                    # CostModelSum adds the weight only when calculating the global cost so we need
+                    # to take it into account here.
+                    self._ocp_cost_value[r, c] = w * d.cost
+                    cj = idof
+                    self._ocp_cost_jacobian[r, cj : cj + d.Lx.shape[0]] = w * d.Lx
+                    cj += d.Lx.shape[0]
+                    self._ocp_cost_jacobian[r, cj : cj + d.Lu.shape[0]] = w * d.Lu
+                idof += d.Lx.shape[0] + d.Lu.shape[0]
 
+        assert idof == self._ocp_cost_jacobian.shape[1]
         self._mpl_data_ready = True
 
     def _init_cost_plot(self):
-        x = np.arange(self._ocp_cost_data.shape[0])  # the label locations
-        width = 0.9 / self._ocp_cost_data.shape[1]  # the width of the bars
+        x = np.arange(self._ocp_cost_value.shape[1])  # the label locations
+        width = 0.9 / self._ocp_cost_value.shape[0]  # the width of the bars
         multiplier = 0
 
         self._mpl_rects = []
-        for ic, cost in enumerate(self._ocp_cost_data.T):
+        for ic, cost in enumerate(self._ocp_cost_value):
             offset = width * multiplier
-            rects = self._mpl_ax.bar(
+            rects = self._mpl_ax_value.bar(
                 x + offset, cost, width, label=self._ocp_cost_keys[ic]
             )
             self._mpl_rects.append(rects)
             multiplier += 1
 
         dt = self._agimus_controller_node_params["ocp.dt"].double_value
-        self._mpl_ax.set_ylabel("cost value")
-        self._mpl_ax.set_xlabel("OCP node (ms)")
-        self._mpl_ax.set_xticks(
+        self._mpl_ax_value.set_ylabel("cost value")
+        self._mpl_ax_value.set_xlabel("OCP node (ms)")
+        self._mpl_ax_value.set_xticks(
             x + 0.45, [f"{int(dt * 1000 * i)}" for i in self._horizon_indices]
         )
-        self._mpl_ax.legend(loc="upper center")
+        self._mpl_ax_value.legend(loc="upper center")
+
+        self._mpl_image = self._mpl_ax_jacobian.imshow(
+            self._ocp_cost_jacobian,
+            cmap="bwr",
+            interpolation="none",
+            aspect="auto",
+            vmin=-1.0,
+            vmax=1.0,
+        )
+        self._mpl_ax_jacobian.set_yticks(
+            np.arange(len(self._ocp_cost_keys)), self._ocp_cost_keys
+        )
+
+        idof = 0
+        xticks, xticks_label = list(), list()
+        for c, (data) in enumerate(self._ocp_node_datas()):
+            cost_data = next(iter(data.differential.costs.costs))
+            d = cost_data.data()
+            xticks.extend([idof, idof + d.Lx.shape[0]])
+            xticks_label.extend([f"x{c}", f"u{c}"])
+            idof += d.Lx.shape[0] + d.Lu.shape[0]
+
+        self._mpl_ax_jacobian.set_xticks(xticks[0::2], xticks_label[0::2])
+        self._mpl_ax_jacobian.set_xticks(xticks[1::2], xticks_label[1::2], minor=True)
+        self._mpl_ax_jacobian.grid(axis="x", which="major", ls="-")
+        self._mpl_ax_jacobian.grid(axis="x", which="minor", ls="--")
+        self._mpl_ax_jacobian.set_title("Normalized Jacobian of the cost function")
+        self._mpl_ax_jacobian.set_xlabel("OCP variables")
+        plt.colorbar(self._mpl_image, ax=self._mpl_ax_jacobian, location="bottom")
 
     def _update_cost_plot(self, _):
         """Function for for adding data to axis.
@@ -338,28 +398,36 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
 
         if self._stop_requested:
             self._mpl_ani.pause()
-            return self._mpl_ax
+            return self._mpl_ax_value
 
         # lock thread
         with self._mpl_lock:
             if not hasattr(self, "_mpl_rects"):
                 self._init_cost_plot()
             else:
-                for rects, costs in zip(self._mpl_rects, self._ocp_cost_data.T):
+                for rects, costs in zip(self._mpl_rects, self._ocp_cost_value):
                     for rect, cost in zip(rects, costs):
                         rect.set_height(cost)
+                self._mpl_ax_value.set_ylim(ymax=np.nanmax(self._ocp_cost_value))
 
-            self._mpl_ax.set_ylim(ymax=np.nanmax(self._ocp_cost_data))
-            return self._mpl_ax
+                s = np.max(np.abs(self._ocp_cost_jacobian))
+                np.save("/tmp/data.npy", self._ocp_cost_jacobian)
+                self._mpl_image.set_data(self._ocp_cost_jacobian / s)
 
-    def plot_cost(self):
+            return self._mpl_ax_value, self._mpl_ax_jacobian
+
+    def plot_cost(self, update_interval_ms=250):
         """Function for initializing and showing matplotlib animation."""
-        self._mpl_fig, self._mpl_ax = plt.subplots()
+        self._mpl_fig, (self._mpl_ax_value, self._mpl_ax_jacobian) = plt.subplots(
+            nrows=2,
+            ncols=1,
+            layout="tight",
+        )
 
         self._mpl_ani = mpl_anim.FuncAnimation(
             self._mpl_fig,
             self._update_cost_plot,
-            interval=500,
+            interval=update_interval_ms,
         )
         plt.show()
 

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -17,7 +17,6 @@ from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy, HistoryPo
 from builtin_interfaces.msg import Duration as DurationMsg
 from std_msgs.msg import Header, ColorRGBA
 from visualization_msgs.msg import MarkerArray, Marker
-from geometry_msgs.msg import Pose
 from agimus_msgs.msg import MpcDebug, MpcInput
 
 from tf2_ros import TransformException
@@ -34,11 +33,11 @@ from agimus_controller_ros.ros_utils import (
     get_params_from_node,
     mpc_msg_to_weighted_traj_point,
     transform_msg_to_se3,
+    se3_to_pose_msg,
 )
 
 from linear_feedback_controller_msgs_py.numpy_conversions import matrix_msg_to_numpy
 import pinocchio
-import eigenpy
 
 
 def _capsule_as_markers(
@@ -54,7 +53,7 @@ def _capsule_as_markers(
     cylinder.scale.x = cap.radius
     cylinder.scale.y = cap.radius
     cylinder.scale.z = 2 * cap.halfLength
-    pinocchio_se3_to_geometry_msg_pose(M, cylinder.pose)
+    cylinder.pose = se3_to_pose_msg(M)
 
     M2 = pinocchio.SE3.Identity()
 
@@ -65,7 +64,7 @@ def _capsule_as_markers(
     sphere1.scale.y = cap.radius
     sphere1.scale.z = cap.radius
     M2.translation[2] = cap.halfLength
-    pinocchio_se3_to_geometry_msg_pose(M * M2, sphere1.pose)
+    sphere1.pose = se3_to_pose_msg(M * M2)
 
     sphere2 = Marker(**marker_args)
     sphere2.id = 2
@@ -74,23 +73,9 @@ def _capsule_as_markers(
     sphere2.scale.y = cap.radius
     sphere2.scale.z = cap.radius
     M2.translation[2] = -cap.halfLength
-    pinocchio_se3_to_geometry_msg_pose(M * M2, sphere2.pose)
+    sphere2.pose = se3_to_pose_msg(M * M2)
 
     return cylinder, sphere1, sphere2
-
-
-def pinocchio_se3_to_geometry_msg_pose(M: pinocchio.SE3, pose: Pose) -> Pose:
-    "Store in `pose` message the transform `M`"
-    pose.position.x = M.translation[0]
-    pose.position.y = M.translation[1]
-    pose.position.z = M.translation[2]
-
-    q = eigenpy.Quaternion(M.rotation)
-    pose.orientation.x = q.x
-    pose.orientation.y = q.y
-    pose.orientation.z = q.z
-    pose.orientation.w = q.w
-    return pose
 
 
 class MPCDebuggerNode(Node, RobotModelsMixin):
@@ -561,7 +546,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         for state, marker in zip(states, self._pred_marker_array.markers):
             pinocchio.forwardKinematics(self.rmodel, self.rdata, state[:nq])
             M = pinocchio.updateFramePlacement(self.rmodel, self.rdata, self._fid)
-            pinocchio_se3_to_geometry_msg_pose(M, marker.pose)
+            marker.pose = se3_to_pose_msg(M)
 
         self._remove_old_references(msg.trajectory_point_id)
         if msg.trajectory_point_id == self._references[0].point.id:
@@ -579,7 +564,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                 assert len(state) == nq, f"{len(state)} == {nq}"
                 pinocchio.forwardKinematics(self.rmodel, self.rdata, np.asarray(state))
                 M = pinocchio.updateFramePlacement(self.rmodel, self.rdata, self._fid)
-                pinocchio_se3_to_geometry_msg_pose(M, marker.pose)
+                marker.pose = se3_to_pose_msg(M)
 
             if len(self._references) > self._horizon_indices[-1]:
                 controls = matrix_msg_to_numpy(msg.control_predictions)

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -1,9 +1,16 @@
+import itertools
 import numpy as np
+import numpy.typing as npt
 import coal
 import rclpy
 import rclpy.duration
 import sys
 import argparse
+
+import threading
+import matplotlib.pyplot as plt
+import matplotlib.animation as mpl_anim
+
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy, HistoryPolicy
 
@@ -13,8 +20,21 @@ from visualization_msgs.msg import MarkerArray, Marker
 from geometry_msgs.msg import Pose
 from agimus_msgs.msg import MpcDebug, MpcInput
 
+from tf2_ros import TransformException
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+
+from agimus_controller.ocp.ocp_croco_generic import OCPCrocoGeneric
+from agimus_controller.ocp_param_base import OCPParamsBaseCroco, DTFactorsNSeq
+from agimus_controller.trajectory import (
+    WeightedTrajectoryPoint,
+)
 from agimus_controller_ros.agimus_controller import RobotModelsMixin
-from agimus_controller_ros.ros_utils import get_params_from_node
+from agimus_controller_ros.ros_utils import (
+    get_params_from_node,
+    mpc_msg_to_weighted_traj_point,
+    transform_msg_to_se3,
+)
 
 from linear_feedback_controller_msgs_py.numpy_conversions import matrix_msg_to_numpy
 import pinocchio
@@ -80,6 +100,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
     - publishes the current MPC prediction as markers.
     - publishes the current MPC references as markers.
     - publishes the capsules used for collision avoidance as markers.
+    - show a bar plot of the items of the cost function.
 
     The markers can be visualized in RViz.
     """
@@ -102,36 +123,13 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         self._parent_frame_name = parent_frame_name
         self._marker_size = marker_size
 
-        self.init_ros_robot_creation()
-        params = get_params_from_node(
-            self,
-            "agimus_controller_node",
-            [
-                "free_flyer",
-                "ocp.dt_factor_n_seq.factors",
-                "ocp.dt_factor_n_seq.n_steps",
-                "collision_as_capsule",
-                "self_collision",
-                "ocp.armature",
-            ],
-        )
-        self._robot_has_free_flyer = params[0].bool_value
-        dt_factors = params[1].integer_array_value
-        dt_n_steps = params[2].integer_array_value
+        self._mpl_lock = threading.Lock()
+        self._mpl_data_ready = False
+        self._stop_requested = False
 
-        self._collision_as_capsule = params[3].bool_value
-        self._self_collision = params[4].bool_value
-        self._ocp_armature = np.array(params[5].double_array_value)
-        self._horizon_indices = np.cumsum(
-            sum(
-                (
-                    (factor,) * n_steps
-                    for factor, n_steps in zip(dt_factors, dt_n_steps)
-                ),
-                (0,),
-            )
-        )
-        self._references: list[MpcInput] = list()
+        self.init_ros_robot_creation()
+        self._get_agimus_controller_node_params()
+        self._references: list[WeightedTrajectoryPoint] = list()
 
         self._mpc_input_sub = self.create_subscription(
             MpcInput,
@@ -143,6 +141,227 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
             ),
         )
         self._init_timer = self.create_timer(0.1, self.initialization_callback)
+
+    def _get_agimus_controller_node_params(self):
+        names = [
+            "free_flyer",
+            "ocp.dt_factor_n_seq.factors",
+            "ocp.dt_factor_n_seq.n_steps",
+            "collision_as_capsule",
+            "self_collision",
+            "ocp.armature",
+            "ocp.definition_yaml_file",
+            "ocp.dt",
+            "ocp.horizon_size",
+            # "ocp.max_iter",
+            # "ocp.max_qp_iter",
+            # "ocp.activate_callback",
+        ]
+        params = get_params_from_node(self, "agimus_controller_node", names)
+
+        self._agimus_controller_node_params = dict(zip(names, params))
+
+        self._robot_has_free_flyer = params[0].bool_value
+        dt_factors = params[1].integer_array_value
+        dt_n_steps = params[2].integer_array_value
+        self._ocp_dt_factor_n_seq = DTFactorsNSeq(dt_factors, dt_n_steps)
+
+        self._collision_as_capsule = params[3].bool_value
+        self._self_collision = params[4].bool_value
+        self._ocp_armature = np.array(params[5].double_array_value)
+
+        self._horizon_indices = np.cumsum(
+            sum(
+                (
+                    (factor,) * n_steps
+                    for factor, n_steps in zip(dt_factors, dt_n_steps)
+                ),
+                (0,),
+            )
+        )
+
+    def _initialize_capsules(self):
+        capsules = []
+        for i, go in enumerate(self.robot_models.collision_model.geometryObjects):
+            if isinstance(go.geometry, coal.Capsule):
+                frame = self.rmodel.frames[go.parentFrame]
+                while (
+                    frame.parentFrame > 0
+                    and self.rmodel.frames[frame.parentFrame].type != pinocchio.JOINT
+                ):
+                    frame = self.rmodel.frames[frame.parentFrame]
+
+                capsules.extend(
+                    _capsule_as_markers(
+                        go.geometry,
+                        M=frame.placement.inverse() * go.placement,
+                        parent_name=frame.name,
+                        ns=go.name,
+                    )
+                )
+        self._capsule_markers = MarkerArray(markers=capsules)
+        if len(capsules) == 0:
+            self.get_logger().warn(
+                "No capsule found in the robot model. If you expect some, make sure you passed the same URDF as agimus_controller_node."
+            )
+
+        self._capsules_markers_pub = self.create_publisher(
+            MarkerArray,
+            "capsules_markers",
+            qos_profile=QoSProfile(
+                depth=1,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                history=HistoryPolicy.KEEP_LAST,
+            ),
+        )
+        self._capsules_markers_pub.publish(self._capsule_markers)
+
+    def _ocp_node_datas(self):
+        return itertools.chain(
+            self._ocp._problem.runningDatas, [self._ocp._problem.terminalData]
+        )
+
+    def _initialize_ocp(self):
+        params = self._agimus_controller_node_params
+        ocp_params = OCPParamsBaseCroco(
+            dt=params["ocp.dt"].double_value,
+            dt_factor_n_seq=self._ocp_dt_factor_n_seq,
+            horizon_size=params["ocp.horizon_size"].integer_value,
+            solver_iters=10,
+            callbacks=False,
+            qp_iters=100,
+            use_debug_data=False,
+            n_threads=1,
+        )
+
+        yaml_file = params["ocp.definition_yaml_file"].string_value
+        if yaml_file == "":
+            yaml_file = OCPCrocoGeneric.get_default_yaml_file("ocp_goal_reaching.yaml")
+        self.get_logger().info(f"Loading OCP definition file {yaml_file}")
+        self._ocp = OCPCrocoGeneric(self.robot_models, ocp_params, yaml_file)
+
+        if len(self._ocp.input_transforms) > 0:
+            self._tf_buffer = Buffer()
+            self._tf_listener = TransformListener(self._tf_buffer, self)
+
+        cost_keys = {}
+        self._ocp_cost_idx = []
+        for data in self._ocp_node_datas():
+            idx = []
+            for cost_item in data.differential.costs.costs:
+                name = cost_item.key()
+                if name not in cost_keys:
+                    cost_keys[name] = len(cost_keys)
+                idx.append(cost_keys[name])
+
+            self._ocp_cost_idx.append(idx)
+
+        self._ocp_cost_keys = dict(map(reversed, cost_keys.items()))
+        self._ocp_cost_data = np.empty(
+            (self._ocp._problem.T + 1, len(cost_keys)), np.float64
+        )
+        self._ocp_cost_data[:] = np.nan
+
+    def _evaluate_ocp(
+        self, states: npt.NDArray[np.float64], controls: npt.NDArray[np.float64]
+    ):
+        # Step 1: Update references
+        # Read transforms from TF. Note that doing do introduces a delay.
+        now = self.get_clock().now()
+        transforms = self._ocp.input_transforms
+        for key in transforms:
+            parent_frame, child_frame = key
+            try:
+                t = self._tf_buffer.lookup_transform(parent_frame, child_frame, now)
+                M = transform_msg_to_se3(t.transform)
+            except TransformException as ex:
+                self.get_logger().info(
+                    f"Could not transform {parent_frame} to {child_frame}: {ex}",
+                    throttle_duration_sec=1.0,
+                )
+                M = None
+            transforms[key] = M
+
+        # Update the references from the horizon.
+        references = [self._references[i] for i in self._horizon_indices]
+        self._ocp.set_reference_weighted_trajectory(references)
+
+        # Step 2: Build state and control and evaluate the OCP
+        x = [np.asarray(state) for state in states]
+        u = [np.asarray(control) for control in controls]
+        problem = self._ocp._problem
+        problem.calc(x, u)
+
+        # Step 3: retrieve the individual cost items.
+        with self._mpl_lock:
+            for r, (cost_idx, data) in enumerate(
+                zip(self._ocp_cost_idx, self._ocp_node_datas())
+            ):
+                for c, cost_item in zip(cost_idx, data.differential.costs.costs):
+                    self._ocp_cost_data[r, c] = cost_item.data().cost
+
+        self._mpl_data_ready = True
+
+    def _init_cost_plot(self):
+        x = np.arange(self._ocp_cost_data.shape[0])  # the label locations
+        width = 0.9 / self._ocp_cost_data.shape[1]  # the width of the bars
+        multiplier = 0
+
+        self._mpl_rects = []
+        for ic, cost in enumerate(self._ocp_cost_data.T):
+            offset = width * multiplier
+            rects = self._mpl_ax.bar(
+                x + offset, cost, width, label=self._ocp_cost_keys[ic]
+            )
+            self._mpl_rects.append(rects)
+            multiplier += 1
+
+        dt = self._agimus_controller_node_params["ocp.dt"].double_value
+        self._mpl_ax.set_ylabel("cost value")
+        self._mpl_ax.set_xlabel("OCP node (ms)")
+        self._mpl_ax.set_xticks(
+            x + 0.45, [f"{int(dt * 1000 * i)}" for i in self._horizon_indices]
+        )
+        self._mpl_ax.legend(loc="upper center")
+
+    def _update_cost_plot(self, _):
+        """Function for for adding data to axis.
+
+        Args:
+            _ : Dummy variable that is required for matplotlib animation.
+
+        Returns:
+            Axes object for matplotlib
+        """
+        if not self._mpl_data_ready:
+            return
+
+        if self._stop_requested:
+            self._mpl_ani.pause()
+            return self._mpl_ax
+
+        # lock thread
+        with self._mpl_lock:
+            if not hasattr(self, "_mpl_rects"):
+                self._init_cost_plot()
+            else:
+                for rects, costs in zip(self._mpl_rects, self._ocp_cost_data.T):
+                    for rect, cost in zip(rects, costs):
+                        rect.set_height(cost)
+
+            self._mpl_ax.set_ylim(ymax=np.nanmax(self._ocp_cost_data))
+            return self._mpl_ax
+
+    def plot_cost(self):
+        """Function for initializing and showing matplotlib animation."""
+        self._mpl_fig, self._mpl_ax = plt.subplots()
+
+        self._mpl_ani = mpl_anim.FuncAnimation(
+            self._mpl_fig,
+            self._update_cost_plot,
+            interval=500,
+        )
+        plt.show()
 
     def initialization_callback(self):
         if not self.ros_robot_ready():
@@ -166,29 +385,8 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         self.rdata = self.rmodel.createData()
         self._fid = self.rmodel.getFrameId(self._frame_name)
 
-        capsules = []
-        for i, go in enumerate(self.robot_models.collision_model.geometryObjects):
-            if isinstance(go.geometry, coal.Capsule):
-                frame = self.rmodel.frames[go.parentFrame]
-                while (
-                    frame.parentFrame > 0
-                    and self.rmodel.frames[frame.parentFrame].type != pinocchio.JOINT
-                ):
-                    frame = self.rmodel.frames[frame.parentFrame]
-
-                capsules.extend(
-                    _capsule_as_markers(
-                        go.geometry,
-                        M=frame.placement.inverse() * go.placement,
-                        parent_name=frame.name,
-                        ns=go.name,
-                    )
-                )
-        self._capsule_markers = MarkerArray(markers=capsules)
-        if len(self._capsule_markers) == 0:
-            self.get_logger().warn(
-                "No capsule found in the robot model. If you expect some, make sure you passed the same URDF as agimus_controller_node."
-            )
+        self._initialize_capsules()
+        self._initialize_ocp()
 
         self._pred_marker_array = MarkerArray(
             markers=self._create_marker_array(
@@ -231,24 +429,17 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                 reliability=ReliabilityPolicy.RELIABLE,
             ),
         )
-        self._capsules_markers_pub = self.create_publisher(
-            MarkerArray,
-            "capsules_markers",
-            qos_profile=QoSProfile(
-                depth=1,
-                durability=DurabilityPolicy.TRANSIENT_LOCAL,
-                history=HistoryPolicy.KEEP_LAST,
-            ),
-        )
-        self._capsules_markers_pub.publish(self._capsule_markers)
         self.get_logger().info("init done")
 
     def mpc_input_callback(self, msg: MpcInput):
+        w_traj_point = mpc_msg_to_weighted_traj_point(
+            msg, time_ns=self.get_clock().now().nanoseconds
+        )
         if len(self._references) > 0:
-            assert msg.id == self._references[-1].id + 1, (
+            assert w_traj_point.point.id == self._references[-1].point.id + 1, (
                 "MPC input ids are expected to be a sequence of consecutive increasing integers."
             )
-        self._references.append(msg)
+        self._references.append(w_traj_point)
 
     def _create_marker_array(
         self, namespace: str, size: int, rgba0, rgba1
@@ -283,7 +474,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         return markers
 
     def _remove_old_references(self, id: int):
-        while self._references[0].id < id:
+        while self._references[0].point.id < id:
             self._references.pop(0)
 
     def mpc_debug_to_markers(self, msg: MpcDebug):
@@ -298,7 +489,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
             pinocchio_se3_to_geometry_msg_pose(M, marker.pose)
 
         self._remove_old_references(msg.trajectory_point_id)
-        if msg.trajectory_point_id == self._references[0].id:
+        if msg.trajectory_point_id == self._references[0].point.id:
             assert len(self._horizon_indices) == len(self._ref_marker_array.markers), (
                 f"{len(self._horizon_indices)} != {len(self._ref_marker_array.markers)}"
             )
@@ -309,19 +500,23 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                         throttle_duration_sec=1.0,
                     )
                     break
-                state = self._references[i].q
+                state = self._references[i].point.robot_configuration
                 assert len(state) == nq, f"{len(state)} == {nq}"
                 pinocchio.forwardKinematics(self.rmodel, self.rdata, np.asarray(state))
                 M = pinocchio.updateFramePlacement(self.rmodel, self.rdata, self._fid)
                 pinocchio_se3_to_geometry_msg_pose(M, marker.pose)
+
+            if len(self._references) > self._horizon_indices[-1]:
+                controls = matrix_msg_to_numpy(msg.control_predictions)
+                self._evaluate_ocp(states, controls)
+            self._mpc_ref_markers_pub.publish(self._ref_marker_array)
         else:
             self.get_logger().warn(
-                f"First ref id: {self._references[0].id}. Msg id: {msg.trajectory_reference_id}",
+                f"First ref id: {self._references[0].point.id}. Msg id: {msg.trajectory_reference_id}",
                 throttle_duration_sec=1.0,
             )
 
         self._mpc_pred_markers_pub.publish(self._pred_marker_array)
-        self._mpc_ref_markers_pub.publish(self._ref_marker_array)
         if msg.trajectory_point_id % 10 == 0:
             self._capsules_markers_pub.publish(self._capsule_markers)
 
@@ -353,6 +548,11 @@ def main(args=None):
     parser.add_argument(
         "--marker-size", type=float, default=0.01, help="set the `marker.scale` field."
     )
+    parser.add_argument(
+        "--cost-plot",
+        action=argparse.BooleanOptionalAction,
+        help="create a plot of the cost function.",
+    )
 
     arguments = parser.parse_args(filtered_args[1:])  # Skip the script name
 
@@ -362,10 +562,24 @@ def main(args=None):
         marker_size=arguments.marker_size,
     )
 
+    if arguments.cost_plot:
+        executor = rclpy.executors.MultiThreadedExecutor()
+        executor.add_node(node)
+        thread = threading.Thread(target=executor.spin, daemon=True)
     try:
-        rclpy.spin(node)
+        if arguments.cost_plot:
+            thread.start()
+            node.plot_cost()
+        else:
+            rclpy.spin(node)
     except KeyboardInterrupt:
-        pass
+        if arguments.cost_plot:
+            # TODO I don't know how to request the matplotlib figure to be closed.
+            # My attempt have not been successful.
+            node._stop_requested = True
+            plt.close(node._mpl_fig)
+            executor.shutdown()
+            thread.join()
     finally:
         node.destroy_node()
         rclpy.shutdown()

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -1,12 +1,14 @@
 import numpy as np
+import coal
 import rclpy
 import rclpy.duration
 import sys
 import argparse
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, ReliabilityPolicy
+from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy, HistoryPolicy
 
 from builtin_interfaces.msg import Duration as DurationMsg
+from std_msgs.msg import Header, ColorRGBA
 from visualization_msgs.msg import MarkerArray, Marker
 from geometry_msgs.msg import Pose
 from agimus_msgs.msg import MpcDebug, MpcInput
@@ -17,6 +19,44 @@ from agimus_controller_ros.ros_utils import get_params_from_node
 from linear_feedback_controller_msgs_py.numpy_conversions import matrix_msg_to_numpy
 import pinocchio
 import eigenpy
+
+
+def _capsule_as_markers(
+    cap: coal.Cylinder, M: pinocchio.SE3, parent_name: str, **marker_args
+) -> list[Marker]:
+    marker_args.setdefault("action", Marker.ADD)
+    marker_args.setdefault("color", ColorRGBA(r=1.0, g=0.0, b=0.0, a=1.0))
+    marker_args.setdefault("lifetime", DurationMsg(sec=100000))
+    marker_args.setdefault("header", Header(frame_id=parent_name))
+    cylinder = Marker(**marker_args)
+    cylinder.id = 0
+    cylinder.type = Marker.CYLINDER
+    cylinder.scale.x = cap.radius
+    cylinder.scale.y = cap.radius
+    cylinder.scale.z = 2 * cap.halfLength
+    pinocchio_se3_to_geometry_msg_pose(M, cylinder.pose)
+
+    M2 = pinocchio.SE3.Identity()
+
+    sphere1 = Marker(**marker_args)
+    sphere1.id = 1
+    sphere1.type = Marker.SPHERE
+    sphere1.scale.x = cap.radius
+    sphere1.scale.y = cap.radius
+    sphere1.scale.z = cap.radius
+    M2.translation[2] = cap.halfLength
+    pinocchio_se3_to_geometry_msg_pose(M * M2, sphere1.pose)
+
+    sphere2 = Marker(**marker_args)
+    sphere2.id = 2
+    sphere2.type = Marker.SPHERE
+    sphere2.scale.x = cap.radius
+    sphere2.scale.y = cap.radius
+    sphere2.scale.z = cap.radius
+    M2.translation[2] = -cap.halfLength
+    pinocchio_se3_to_geometry_msg_pose(M * M2, sphere2.pose)
+
+    return cylinder, sphere1, sphere2
 
 
 def pinocchio_se3_to_geometry_msg_pose(M: pinocchio.SE3, pose: Pose) -> Pose:
@@ -37,7 +77,11 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
     """ROS node class to assist users of the AgimusController ROS node.
 
     Features:
-    - publishes the current MPC prediction as markers that can be viewed in RViz.
+    - publishes the current MPC prediction as markers.
+    - publishes the current MPC references as markers.
+    - publishes the capsules used for collision avoidance as markers.
+
+    The markers can be visualized in RViz.
     """
 
     def __init__(
@@ -66,12 +110,18 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                 "free_flyer",
                 "ocp.dt_factor_n_seq.factors",
                 "ocp.dt_factor_n_seq.n_steps",
+                "collision_as_capsule",
+                "self_collision",
+                "ocp.armature",
             ],
         )
-
         self._robot_has_free_flyer = params[0].bool_value
         dt_factors = params[1].integer_array_value
         dt_n_steps = params[2].integer_array_value
+
+        self._collision_as_capsule = params[3].bool_value
+        self._self_collision = params[4].bool_value
+        self._ocp_armature = np.array(params[5].double_array_value)
         self._horizon_indices = np.cumsum(
             sum(
                 (
@@ -105,11 +155,40 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         self.destroy_timer(self._init_timer)
 
         self.get_logger().info("create robot...")
-        self.create_robot_models(free_flyer=self._robot_has_free_flyer)
+        self.create_robot_models(
+            free_flyer=self._robot_has_free_flyer,
+            collision_as_capsule=self._collision_as_capsule,
+            self_collision=self._self_collision,
+            armature=self._ocp_armature,
+        )
         frame_name_ok = self.rmodel.existFrame(self._frame_name)
         assert frame_name_ok, f"Frame {self._frame_name} could not be found."
         self.rdata = self.rmodel.createData()
         self._fid = self.rmodel.getFrameId(self._frame_name)
+
+        capsules = []
+        for i, go in enumerate(self.robot_models.collision_model.geometryObjects):
+            if isinstance(go.geometry, coal.Capsule):
+                frame = self.rmodel.frames[go.parentFrame]
+                while (
+                    frame.parentFrame > 0
+                    and self.rmodel.frames[frame.parentFrame].type != pinocchio.JOINT
+                ):
+                    frame = self.rmodel.frames[frame.parentFrame]
+
+                capsules.extend(
+                    _capsule_as_markers(
+                        go.geometry,
+                        M=frame.placement.inverse() * go.placement,
+                        parent_name=frame.name,
+                        ns=go.name,
+                    )
+                )
+        self._capsule_markers = MarkerArray(markers=capsules)
+        if len(self._capsule_markers) == 0:
+            self.get_logger().warn(
+                "No capsule found in the robot model. If you expect some, make sure you passed the same URDF as agimus_controller_node."
+            )
 
         self._pred_marker_array = MarkerArray(
             markers=self._create_marker_array(
@@ -152,6 +231,16 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                 reliability=ReliabilityPolicy.RELIABLE,
             ),
         )
+        self._capsules_markers_pub = self.create_publisher(
+            MarkerArray,
+            "capsules_markers",
+            qos_profile=QoSProfile(
+                depth=1,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                history=HistoryPolicy.KEEP_LAST,
+            ),
+        )
+        self._capsules_markers_pub.publish(self._capsule_markers)
         self.get_logger().info("init done")
 
     def mpc_input_callback(self, msg: MpcInput):
@@ -233,6 +322,8 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
 
         self._mpc_pred_markers_pub.publish(self._pred_marker_array)
         self._mpc_ref_markers_pub.publish(self._ref_marker_array)
+        if msg.trajectory_point_id % 10 == 0:
+            self._capsules_markers_pub.publish(self._capsule_markers)
 
 
 def main(args=None):

--- a/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
+++ b/agimus_controller_ros/agimus_controller_ros/mpc_debugger_node.py
@@ -124,6 +124,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         self._marker_size = marker_size
 
         self._mpl_lock = threading.Lock()
+        self._ocp_update_requested = threading.Event()
         self._mpl_data_ready = False
         self._stop_requested = False
 
@@ -280,6 +281,9 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
     def _evaluate_ocp(
         self, states: npt.NDArray[np.float64], controls: npt.NDArray[np.float64]
     ):
+        if self._ocp_update_requested.is_set():
+            return
+
         # Step 1: Update references
         # Read transforms from TF. Note that doing do introduces a delay.
         now = self.get_clock().now()
@@ -331,6 +335,8 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                 idof += d.Lx.shape[0] + d.Lu.shape[0]
 
         assert idof == self._ocp_cost_jacobian.shape[1]
+
+        self._ocp_update_requested.set()
         self._mpl_data_ready = True
 
     def _init_cost_plot(self):
@@ -393,7 +399,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
         Returns:
             Axes object for matplotlib
         """
-        if not self._mpl_data_ready:
+        if not self._ocp_update_requested.is_set():
             return
 
         if self._stop_requested:
@@ -414,6 +420,7 @@ class MPCDebuggerNode(Node, RobotModelsMixin):
                 np.save("/tmp/data.npy", self._ocp_cost_jacobian)
                 self._mpl_image.set_data(self._ocp_cost_jacobian / s)
 
+            self._ocp_update_requested.clear()
             return self._mpl_ax_value, self._mpl_ax_jacobian
 
     def plot_cost(self, update_interval_ms=250):


### PR DESCRIPTION
The MPC debugger node can now:
- convert the capsules used for collision avoidance as marker array, visible in RViz
- show a bar plot of the items of the cost function
- show the jacobian of the cost function

The fix in agimus controller node is to make sure TF has some time to fill its buffer before a lookup is made.

The capsules in RViz:
![image](https://github.com/user-attachments/assets/eb9d193a-50e0-44ec-8723-f956767f2ecc)

The bar plot:
![image](https://github.com/user-attachments/assets/9f51c679-8f4b-4530-87bf-356f33c7768c)