### PR TITLE
Add ability to have force feedback.

### DIFF
--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -9,6 +9,11 @@ import yaml
 import pinocchio as pin
 import typing as T
 
+try:
+    import force_feedback_mpc
+except ImportError:
+    force_feedback_mpc = None
+
 from agimus_controller.ocp_base_croco import (
     OCPBaseCroco,
     RobotModels,
@@ -464,6 +469,81 @@ class DifferentialActionModelFreeFwdDynamics(DifferentialActionModel):
 
 
 @dataclasses.dataclass
+class DAMSoftContactAugmentedFwdDynamics(DifferentialActionModel):
+    class_: T.ClassVar[str] = "DAMSoftContactAugmentedFwdDynamics"
+    costs: T.List[CostModelSumItem]
+    frame_name: str
+    Kp: list[float]
+    Kv: list[float]
+    oPc: tuple[float, float, float]
+
+    with_gravity_torque: bool = False
+
+    enabled_directions: tuple[bool, bool, bool] = (True, True, True)
+
+    def __post_init__(self):
+        assert force_feedback_mpc is not None, "Module force_feedback_mpc not found"
+
+        self._dimension = sum(self.enabled_directions)
+        assert self._dimension in [1, 3], "Soft contact is either 1D or 3D."
+
+    @property
+    def _dam_cls_and_kwargs(self) -> tuple[type, dict]:
+        if self._dimension == 1:
+            axis = "xyz"[self.enabled_directions.index(1)]
+            return force_feedback_mpc.DAMSoftContact1DAugmentedFwdDynamics, {
+                "type": getattr(force_feedback_mpc.Vector3MaskType, axis)
+            }
+        if self._dimension == 3:
+            return force_feedback_mpc.DAMSoftContact3DAugmentedFwdDynamics, {}
+        raise ValueError("Soft contact is either 1D or 3D.")
+
+    def build(self, data: BuildData):
+        costs = self.build_costs(data)
+        fid = data.get_frame_id(self.frame_name)
+        dam_cls, extra_kwargs = self._dam_cls_and_kwargs
+        dam = dam_cls(
+            state=data.state,
+            actuation=data.actuation,
+            costs=costs,
+            frameId=fid,
+            Kp=np.asarray(self.Kp),
+            Kv=np.asarray(self.Kv),
+            oPc=np.asarray(self.oPc),
+            **extra_kwargs,
+        )
+        dam.with_gravity_torque_reg = self.with_gravity_torque_reg
+        dam.tau_grav_weight = 0.0
+        dam.with_force_cost = True
+        dam.f_des = np.zeros(dam.nc)
+        dam.f_weight = np.zeros(dam.nc)
+
+    def update(self, data, dam, pt: WeightedTrajectoryPoint):
+        for cost in self.costs:
+            if cost.update:
+                cost.cost.update(data, dam.costs.costs[cost.name].cost, pt)
+
+        # Update the desired force.
+        assert len(pt.point.forces) == 1, (
+            "Only one end-effector force tracking reference is allowed."
+        )
+        assert len(pt.weights.w_forces) == 1, (
+            "Only one end-effector force tracking reference is allowed."
+        )
+        name, f_weight = next(iter(pt.weights.w_forces.items()))
+        if np.sum(np.abs(f_weight)) > 1e-9:
+            dam.active_contact = True
+            dam.with_force_cost = True
+            dam.f_des = pt.point.forces[name]
+            dam.f_weight = f_weight
+        else:
+            dam.active_contact = False
+            dam.with_force_cost = False
+            dam.f_des = np.zeros(dam.nc)
+            dam.f_weight = np.zeros(dam.nc)
+
+
+@dataclasses.dataclass
 class IntegratedActionModelAbstract:
     differential: DifferentialActionModel
     step_time: float = 0.0
@@ -480,6 +560,20 @@ class IntegratedActionModelEuler(IntegratedActionModelAbstract):
     def build(self, data: BuildData):
         differential = self.differential.build(data)
         return crocoddyl.IntegratedActionModelEuler(
+            differential, self.step_time, self.with_cost_residual
+        )
+
+
+@dataclasses.dataclass
+class IAMSoftContactAugmented(IntegratedActionModelAbstract):
+    class_: T.ClassVar[str] = "IAMSoftContactAugmented"
+
+    def __post_init__(self):
+        assert force_feedback_mpc is not None, "Module force_feedback_mpc not found"
+
+    def build(self, data: BuildData):
+        differential = self.differential.build(data)
+        return force_feedback_mpc.IAMSoftContactAugmented(
             differential, self.step_time, self.with_cost_residual
         )
 

--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -68,6 +68,18 @@ class BuildData:
         dataclasses.field(default_factory=dict)
     )
 
+    def get_frame_id(self, id: int | str) -> int:
+        rmodel: pinocchio.Model = self.state.pinocchio
+        if isinstance(id, str):
+            assert rmodel.existFrame(id), (
+                f"Frame {id} not found in robot model. Available frames are\n{[f.name for f in rmodel.frames]}"
+            )
+            id = rmodel.getFrameId(id)
+        assert isinstance(id, int) and id < rmodel.nframes, (
+            f"Frame index {id} out of range [0, {rmodel.nframes}[."
+        )
+        return id
+
 
 @dataclasses.dataclass
 class ActivationModel:
@@ -149,24 +161,15 @@ class ResidualModelFramePlacement(ResidualModel):
     id: T.Union[str, int]
     pref: T.Optional[npt.NDArray[np.float64]] = None
 
-    def update(self, data, obj, pt: WeightedTrajectoryPoint):
+    def update(self, data: BuildData, obj, pt: WeightedTrajectoryPoint):
         assert len(pt.point.end_effector_poses) == 1
         ee_name, ee_pose = next(iter(pt.point.end_effector_poses.items()))
-        obj.id = self._get_id(data.state, ee_name)
+        obj.id = data.get_frame_id(ee_name)
         obj.reference = ee_pose
         return pt.weights.w_end_effector_poses[ee_name]
 
-    @staticmethod
-    def _get_id(state, id):
-        rmodel: pinocchio.Model = state.pinocchio
-        if isinstance(id, str):
-            assert rmodel.existFrame(id)
-            id = rmodel.getFrameId(id)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
-
     def build(self, data: BuildData):
-        id = self._get_id(data.state, self.id)
+        id = data.get_frame_id(self.id)
         if self.pref is None:
             pref = pinocchio.SE3.Identity()
         else:
@@ -215,18 +218,8 @@ class ResidualModelVisualServoing(ResidualModel):
             obj.reference = wMo_vision * oMf_target
         return weights
 
-    @staticmethod
-    def _get_id(state: crocoddyl.StateMultibody, name: str):
-        rmodel: pinocchio.Model = state.pinocchio
-        assert rmodel.existFrame(name), (
-            f"{name} not found in model. Frames are {[f.name for f in rmodel.frames]}"
-        )
-        id = rmodel.getFrameId(name)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
-
     def build(self, data: BuildData):
-        world_frame_id = self._get_id(data.state, self.world_frame)
+        world_frame_id = data.get_frame_id(self.world_frame)
         f = data.state.pinocchio.frames[world_frame_id]
         assert f.parentJoint == 0, (
             f"Parent joint of world frame ({self.world_frame}) should be 0"
@@ -240,7 +233,7 @@ class ResidualModelVisualServoing(ResidualModel):
 
         data.transforms.setdefault(self.transforms_key, None)
 
-        frame_id = self._get_id(data.state, self.robot_frame)
+        frame_id = data.get_frame_id(self.robot_frame)
         pref = pinocchio.SE3.Identity()
         return crocoddyl.ResidualModelFramePlacement(data.state, frame_id, pref)
 

--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -386,28 +386,39 @@ class ConstraintListItem:
 
 @dataclasses.dataclass
 class DifferentialActionModel:
-    pass
+    costs: T.List[CostModelSumItem]
+
+    @classmethod
+    def from_dict(cls, kwargs: T.Dict[str, T.Any]):
+        for key, item_cls in (("costs", CostModelSumItem),):
+            kwargs[key] = [
+                create_nested_dataclass(item_cls, v) for v in kwargs.get(key, [])
+            ]
+        return cls(**kwargs)
+
+    def build_costs(self, data: BuildData) -> crocoddyl.CostModelSum:
+        costs = crocoddyl.CostModelSum(data.state)
+        for cost in self.costs:
+            c = cost.cost.build(data)
+            costs.addCost(cost.name, c, cost.weight, cost.active)
+        return costs
 
 
 @dataclasses.dataclass
 class DifferentialActionModelFreeFwdDynamics(DifferentialActionModel):
     class_: T.ClassVar[str] = "DifferentialActionModelFreeFwdDynamics"
-    costs: T.List[CostModelSumItem]
     constraints: T.List[ConstraintListItem] = dataclasses.field(default_factory=list)
 
     @classmethod
     def from_dict(cls, kwargs: T.Dict[str, T.Any]):
-        costs = [
-            create_nested_dataclass(CostModelSumItem, v)
-            for v in kwargs.get("costs", [])
-        ]
-        kwargs["costs"] = costs
-        constraints = [
-            create_nested_dataclass(ConstraintListItem, v)
-            for v in kwargs.get("constraints", [])
-        ]
-        kwargs["constraints"] = constraints
-        return DifferentialActionModelFreeFwdDynamics(**kwargs)
+        for key, item_cls in (
+            ("costs", CostModelSumItem),
+            ("constraints", ConstraintListItem),
+        ):
+            kwargs[key] = [
+                create_nested_dataclass(item_cls, v) for v in kwargs.get(key, [])
+            ]
+        return cls(**kwargs)
 
     def needs_colmpc_freefwd_dynamics(self) -> bool:
         for cost in self.costs:
@@ -422,10 +433,7 @@ class DifferentialActionModelFreeFwdDynamics(DifferentialActionModel):
         return False
 
     def build(self, data: BuildData):
-        costs = crocoddyl.CostModelSum(data.state)
-        for cost in self.costs:
-            c = cost.cost.build(data)
-            costs.addCost(cost.name, c, cost.weight, cost.active)
+        costs = self.build_costs(data)
         if self.needs_colmpc_freefwd_dynamics():
             DifferentialActionModelFreeFwdDynamics = (
                 colmpc.DifferentialActionModelFreeFwdDynamics


### PR DESCRIPTION
This is a draft version of the code.

I have even tried to run the code as I have not done the setup. However, the code should be easy to clean on your side. To do so, you have to replace usages of `OCPCrocoForceFeedback` by `OCPCrocoGeneric` and create an OCP definition yaml file.

Starting from the default ocp definition file (`ocp_goal_tracking.yaml`), you have to:
- change the integration action model. The attributes are the same.
- change the differential action model. Many of the args you added to the param class will be attributes of this DAM. The choice between 1D and 3D is done using the `enabled_directions` attributes (e.g. [True,False,False] or [True,True,True])

At the moment, I haven't added
- the frame velocity residual. Tests can be ran without this.
- the frame translation and rotation residual, but you can work with frame placement residual.