### PR TITLE
Ocp with collision

### DIFF
--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -279,6 +279,8 @@ class ResidualDistanceCollisionBase(ResidualModel):
             assert cmodel.existGeometryName(name), f"Geometry object {name} not found."
             cp.append(cmodel.getGeometryId(name))
         cp = pinocchio.CollisionPair(*cp)
+        if not cmodel.existCollisionPair(cp):
+            cmodel.addCollisionPair(cp)
         assert cmodel.existCollisionPair(cp)
         id = cmodel.findCollisionPair(cp)
         assert id < len(cmodel.collisionPairs)

--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -95,13 +95,32 @@ class ActivationModelWeightedQuad(ActivationModel):
 
 
 @dataclasses.dataclass
-class ActivationModelQuadExp(ActivationModel):
-    class_: T.ClassVar[str] = "ActivationModelQuadExp"
+class ActivationModelExp(ActivationModel):
+    class_: T.ClassVar[str] = "ActivationModelExp"
     alpha: float = 1.0
+    exponent: int = 1
 
     def build(self, data: BuildData, residual: crocoddyl.CostModelResidual):
+        assert self.exponent in [1, 2]
+        cls = (
+            colmpc.ActivationModelExp
+            if self.exponent == 1
+            else colmpc.ActivationModelQuadExp
+        )
         # float() is required to allow parsing a float in scientific notation.
-        return colmpc.ActivationModelQuadExp(residual.nr, float(self.alpha))
+        return cls(residual.nr, float(self.alpha))
+
+
+# For backward compatibility
+@dataclasses.dataclass
+class ActivationModelQuadExp(ActivationModelExp):
+    class_: T.ClassVar[str] = "ActivationModelQuadExp"
+    exponent: int = 2
+
+    def __post_init__(self):
+        assert self.exponent == 2, (
+            "ActivationModelQuadExp is provided for backward compatibility. exponent should not be 2 (the default)."
+        )
 
 
 @dataclasses.dataclass
@@ -247,6 +266,8 @@ class ResidualModelVisualServoing(ResidualModel):
 
 @dataclasses.dataclass
 class ResidualDistanceCollisionBase(ResidualModel):
+    # Ideally, this should go with an activation of type
+    # ActivationModelExp with exponent 1.
     collision_pair: T.Tuple[str, str]
 
     def _collision_pair_id(self, cmodel: pinocchio.GeometryModel) -> int:

--- a/agimus_controller_ros/agimus_controller_ros/ros_utils.py
+++ b/agimus_controller_ros/agimus_controller_ros/ros_utils.py
@@ -202,7 +202,11 @@ def get_params_from_node(
     request.names = target_params_name
 
     future = param_client.call_async(request)
-    rclpy.spin_until_future_complete(requester_node, future)
+    while not future.done():
+        rclpy.spin_until_future_complete(requester_node, future, timeout_sec=1.0)
+        requester_node.get_logger().info(
+            f"Waiting for reply from service {service_name}..."
+        )
 
     if future.result() is not None:
         # Ideally, values should be wrapped in rclpy.Parameter


### PR DESCRIPTION
This PR adds
- the ability to specify a different activation function for distance residual
- A better handling of the collision pairs (create if not existing). Note that this makes the collision pair definition by parameters not necessary. I will make another PR later that removes the unnecessary parameters. (@TheoMF FYI)
- Make `get_params_from_node` verbosely wait for service reply (so that user knows that this is the status).

@Kotochleb
From my experiment, the most suited one is ActivationModelExp with exponent 1.