### PR TITLE
Add option to import globals into a file

### DIFF
--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -19,6 +19,16 @@ from agimus_controller.trajectory import (
 )
 
 
+def add_modules(values: dict):
+    """Extends globals of this file with other custom globals. Enables importing of
+    OCP components within `create_croco_dataclasses` from outside of this file.
+
+    Args:
+        values (dict): Dictionary with new globals to add.
+    """
+    globals().update(values)
+
+
 def create_nested_dataclass(cls, values):
     kwargs = {k: create_croco_dataclasses(v) for k, v in values.items()}
     if hasattr(cls, "from_dict"):


### PR DESCRIPTION
In case there is a need for new modules for the OCP that are very task specific, one way I found that avoids replicating huge part of the code is to extend `globals` os the file with new imports. This way new modules can be implemented outside and provided as extra imports.