### PR TITLE
Add support for multiple end effector frames

### DIFF
--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -202,12 +202,12 @@ class ResidualModelFramePlacement(ResidualModel):
     def update(self, data, obj, pt: WeightedTrajectoryPoint):
         assert len(pt.point.end_effector_poses) == 1
         ee_name, ee_pose = next(iter(pt.point.end_effector_poses.items()))
-        obj.id = self._get_id(data.state, ee_name)
+        obj.id = get_frame_id(data.state, ee_name)
         obj.reference = ee_pose
         return pt.weights.w_end_effector_poses[ee_name]
 
     def build(self, data: BuildData):
-        id = self._get_id(data.state, self.id)
+        id = get_frame_id(data.state, self.id)
         if self.pref is None:
             pref = pinocchio.SE3.Identity()
         else:

--- a/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+++ b/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
@@ -66,6 +66,15 @@ def as_dict(obj):
         return obj
 
 
+def get_frame_id(state: crocoddyl.StateMultibody, id: T.Union[str, int]) -> int:
+    rmodel: pinocchio.Model = state.pinocchio
+    if isinstance(id, str):
+        assert rmodel.existFrame(id)
+        id = rmodel.getFrameId(id)
+    assert isinstance(id, int) and id < rmodel.nframes
+    return id
+
+
 @dataclasses.dataclass
 class BuildData:
     state: crocoddyl.StateMultibody
@@ -197,17 +206,34 @@ class ResidualModelFramePlacement(ResidualModel):
         obj.reference = ee_pose
         return pt.weights.w_end_effector_poses[ee_name]
 
-    @staticmethod
-    def _get_id(state, id):
-        rmodel: pinocchio.Model = state.pinocchio
-        if isinstance(id, str):
-            assert rmodel.existFrame(id)
-            id = rmodel.getFrameId(id)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
-
     def build(self, data: BuildData):
         id = self._get_id(data.state, self.id)
+        if self.pref is None:
+            pref = pinocchio.SE3.Identity()
+        else:
+            assert self.pref
+            pref = pinocchio.XYZQUATToSE3(self.pref)
+        return crocoddyl.ResidualModelFramePlacement(data.state, id, pref)
+
+
+@dataclasses.dataclass
+class ResidualModelFramePlacementStatic(ResidualModel):
+    """Variant of ResidualModelFramePlacement requiring statically
+    defined frame, for multi end effector support"""
+
+    class_: T.ClassVar[str] = "ResidualModelFramePlacement"
+    frame_id: T.Optional[str]
+    pref: T.Optional[npt.NDArray[np.float64]] = None
+
+    def update(self, data, obj, pt: WeightedTrajectoryPoint):
+        assert self.frame_id in pt.point.end_effector_poses, (
+            f"end_effector_poses should contains key {self.frame_id}"
+        )
+        obj.reference = pt.point.end_effector_poses[self.frame_id]
+        return pt.weights.w_end_effector_poses[self.frame_id]
+
+    def build(self, data: BuildData):
+        id = get_frame_id(data.state, self.frame_id)
         if self.pref is None:
             pref = pinocchio.SE3.Identity()
         else:
@@ -225,21 +251,38 @@ class ResidualModelFrameTranslation(ResidualModel):
     def update(self, data, obj, pt: WeightedTrajectoryPoint):
         assert len(pt.point.end_effector_poses) == 1
         ee_name, ee_pose = next(iter(pt.point.end_effector_poses.items()))
-        obj.id = self._get_id(data.state, ee_name)
+        obj.id = get_frame_id(data.state, ee_name)
         obj.reference = ee_pose.translation
         return pt.weights.w_end_effector_poses[ee_name][:3]
 
-    @staticmethod
-    def _get_id(state, id):
-        rmodel: pinocchio.Model = state.pinocchio
-        if isinstance(id, str):
-            assert rmodel.existFrame(id)
-            id = rmodel.getFrameId(id)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
+    def build(self, data: BuildData):
+        id = get_frame_id(data.state, self.id)
+        if self.pref is None:
+            pref = np.zeros(3)
+        else:
+            assert self.pref
+            pref = self.pref[:3]
+        return crocoddyl.ResidualModelFrameTranslation(data.state, id, pref)
+
+
+@dataclasses.dataclass
+class ResidualModelFrameTranslationStatic(ResidualModel):
+    """Variant of ResidualModelFrameTranslation requiring statically
+    defined frame, for multi end effector support"""
+
+    class_: T.ClassVar[str] = "ResidualModelFrameTranslation"
+    frame_id: T.Optional[str]
+    pref: T.Optional[npt.NDArray[np.float64]] = None
+
+    def update(self, data, obj, pt: WeightedTrajectoryPoint):
+        assert self.frame_id in pt.point.end_effector_poses, (
+            f"end_effector_poses should contains key {self.frame_id}"
+        )
+        obj.reference = pt.point.end_effector_poses[self.frame_id].translation
+        return pt.weights.w_end_effector_poses[self.frame_id][:3]
 
     def build(self, data: BuildData):
-        id = self._get_id(data.state, self.id)
+        id = get_frame_id(data.state, self.frame_id)
         if self.pref is None:
             pref = np.zeros(3)
         else:
@@ -257,21 +300,38 @@ class ResidualModelFrameRotation(ResidualModel):
     def update(self, data, obj, pt: WeightedTrajectoryPoint):
         assert len(pt.point.end_effector_poses) == 1
         ee_name, ee_pose = next(iter(pt.point.end_effector_poses.items()))
-        obj.id = self._get_id(data.state, ee_name)
+        obj.id = get_frame_id(data.state, ee_name)
         obj.reference = ee_pose.rotation
         return pt.weights.w_end_effector_poses[ee_name][3:]
 
-    @staticmethod
-    def _get_id(state, id):
-        rmodel: pinocchio.Model = state.pinocchio
-        if isinstance(id, str):
-            assert rmodel.existFrame(id)
-            id = rmodel.getFrameId(id)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
+    def build(self, data: BuildData):
+        id = get_frame_id(data.state, self.id)
+        if self.pref is None:
+            pref = np.eye(3)
+        else:
+            assert self.pref
+            pref = pinocchio.Quaternion(self.pref[3:]).toRotationMatrix()
+        return crocoddyl.ResidualModelFrameRotation(data.state, id, pref)
+
+
+@dataclasses.dataclass
+class ResidualModelFrameRotationStatic(ResidualModel):
+    """Variant of ResidualModelFrameRotation requiring statically
+    defined frame, for multi end effector support"""
+
+    class_: T.ClassVar[str] = "ResidualModelFrameRotation"
+    frame_id: T.Optional[str]
+    pref: T.Optional[npt.NDArray[np.float64]] = None
+
+    def update(self, data, obj, pt: WeightedTrajectoryPoint):
+        assert self.frame_id in pt.point.end_effector_poses, (
+            f"end_effector_poses should contains key {self.frame_id}"
+        )
+        obj.reference = pt.point.end_effector_poses[self.frame_id].rotation
+        return pt.weights.w_end_effector_poses[self.frame_id][3:]
 
     def build(self, data: BuildData):
-        id = self._get_id(data.state, self.id)
+        id = get_frame_id(data.state, self.frame_id)
         if self.pref is None:
             pref = np.eye(3)
         else:
@@ -288,28 +348,60 @@ class ResidualModelFrameVelocity(ResidualModel):
     reference_frame: T.Optional[str] = "WORLD"
 
     def __post_init__(self):
-        assert self.reference_frame in ["WORLD", "LOCAL", "LOCAL_WORLD_ALIGNED"], (
+        assert self.reference_frame in [
+            "WORLD",
+            "LOCAL",
+            "LOCAL_WORLD_ALIGNED",
+        ], (
             "ResidualModelFrameVelocity.reference_frame has to be one of: 'WORLD', 'LOCAL', 'LOCAL_WORLD_ALIGNED'."
         )
 
     def update(self, data, obj, pt: WeightedTrajectoryPoint):
         assert len(pt.point.end_effector_velocities) == 1
         ee_name, ee_vel = next(iter(pt.point.end_effector_velocities.items()))
-        obj.id = self._get_id(data.state, ee_name)
+        obj.id = get_frame_id(data.state, ee_name)
         obj.reference = ee_vel
         return pt.weights.w_end_effector_velocities[ee_name]
 
-    @staticmethod
-    def _get_id(state, id):
-        rmodel: pinocchio.Model = state.pinocchio
-        if isinstance(id, str):
-            assert rmodel.existFrame(id)
-            id = rmodel.getFrameId(id)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
+    def build(self, data: BuildData):
+        id = get_frame_id(data.state, self.id)
+        if self.pref is None:
+            pref = pinocchio.Motion(np.zeros(6))
+        else:
+            assert self.pref
+            pref = pinocchio.Motion(self.pref)
+        frame = getattr(pinocchio, self.reference_frame)
+        return crocoddyl.ResidualModelFrameVelocity(data.state, id, pref, frame)
+
+
+@dataclasses.dataclass
+class ResidualModelFrameVelocityStatic(ResidualModel):
+    """Variant of ResidualModelFrameVelocity requiring statically
+    defined frame, for multi end effector support"""
+
+    class_: T.ClassVar[str] = "ResidualModelFrameVelocity"
+    frame_id: T.Optional[str]
+    pref: T.Optional[npt.NDArray[np.float64]] = None
+    reference_frame: T.Optional[str] = "WORLD"
+
+    def __post_init__(self):
+        assert self.reference_frame in [
+            "WORLD",
+            "LOCAL",
+            "LOCAL_WORLD_ALIGNED",
+        ], (
+            "ResidualModelFrameVelocity.reference_frame has to be one of: 'WORLD', 'LOCAL', 'LOCAL_WORLD_ALIGNED'."
+        )
+
+    def update(self, data, obj, pt: WeightedTrajectoryPoint):
+        assert self.frame_id in pt.point.end_effector_velocities, (
+            f"end_effector_velocities should contains key {self.frame_id}"
+        )
+        obj.reference = pt.point.end_effector_velocities[self.frame_id]
+        return pt.weights.w_end_effector_poses[self.frame_id]
 
     def build(self, data: BuildData):
-        id = self._get_id(data.state, self.id)
+        id = get_frame_id(data.state, self.frame_id)
         if self.pref is None:
             pref = pinocchio.Motion(np.zeros(6))
         else:
@@ -359,18 +451,8 @@ class ResidualModelVisualServoing(ResidualModel):
             obj.reference = wMo_vision * oMf_target
         return weights
 
-    @staticmethod
-    def _get_id(state: crocoddyl.StateMultibody, name: str):
-        rmodel: pinocchio.Model = state.pinocchio
-        assert rmodel.existFrame(name), (
-            f"{name} not found in model. Frames are {[f.name for f in rmodel.frames]}"
-        )
-        id = rmodel.getFrameId(name)
-        assert isinstance(id, int) and id < rmodel.nframes
-        return id
-
     def build(self, data: BuildData):
-        world_frame_id = self._get_id(data.state, self.world_frame)
+        world_frame_id = get_frame_id(data.state, self.world_frame)
         f = data.state.pinocchio.frames[world_frame_id]
         assert f.parentJoint == 0, (
             f"Parent joint of world frame ({self.world_frame}) should be 0"
@@ -384,7 +466,7 @@ class ResidualModelVisualServoing(ResidualModel):
 
         data.transforms.setdefault(self.transforms_key, None)
 
-        frame_id = self._get_id(data.state, self.robot_frame)
+        frame_id = get_frame_id(data.state, self.robot_frame)
         pref = pinocchio.SE3.Identity()
         return crocoddyl.ResidualModelFramePlacement(data.state, frame_id, pref)
 

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -353,8 +353,8 @@ class AgimusController(Node, RobotModelsMixin):
             msg, self.get_clock().now().nanoseconds
         )
         self.traj_buffer.append(w_traj_point)
-        self.params.ocp.effector_frame_name = msg.ee_frame_name
-        self.effector_frame_name = msg.ee_frame_name
+        self.params.ocp.effector_frame_name = msg.ee_inputs[0].frame_id
+        self.effector_frame_name = msg.ee_inputs[0].frame_id
 
     def buffer_has_enough_data(self, ratio: float) -> bool:
         """

--- a/agimus_controller_ros/agimus_controller_ros/ros_utils.py
+++ b/agimus_controller_ros/agimus_controller_ros/ros_utils.py
@@ -216,7 +216,7 @@ def weighted_traj_point_to_mpc_msg(w_traj_point: WeightedTrajectoryPoint) -> Mpc
         msg = MpcEEInput(frame_id=frame_id)
 
         pose = w_traj_point.point.end_effector_poses
-        if frame_id in pose and pose[frame_id] is not None:
+        if pose is not None and frame_id in pose and pose[frame_id] is not None:
             wMee = pose[frame_id]
             if isinstance(wMee, pin.SE3):
                 # This is the type defined in the annotation of the class definition
@@ -227,35 +227,49 @@ def weighted_traj_point_to_mpc_msg(w_traj_point: WeightedTrajectoryPoint) -> Mpc
             msg.pose = array_to_ros_pose(wMee)
 
         twist = w_traj_point.point.end_effector_velocities
-        if frame_id in twist and twist[frame_id] is not None:
+        if twist is not None and frame_id in twist and twist[frame_id] is not None:
             msg.twist = motion_to_ros_twist(twist[frame_id])
 
         force = w_traj_point.point.forces
-        if frame_id in force and force[frame_id] is not None:
+        if force is not None and frame_id in force and force[frame_id] is not None:
             msg.force = force_to_ros_wrench(force[frame_id])
 
         w_pose = w_traj_point.weights.w_end_effector_poses
-        if frame_id in w_pose and w_pose[frame_id] is not None:
+        if w_pose is not None and frame_id in w_pose and w_pose[frame_id] is not None:
             msg.w_pose = w_pose[frame_id]
 
         w_twist = w_traj_point.weights.w_end_effector_velocities
-        if frame_id in w_twist and w_twist[frame_id] is not None:
+        if (
+            w_twist is not None
+            and frame_id in w_twist
+            and w_twist[frame_id] is not None
+        ):
             msg.w_twist = w_twist[frame_id]
 
         w_force = w_traj_point.weights.w_forces
-        if frame_id in w_force and w_force[frame_id] is not None:
+        if (
+            w_force is not None
+            and frame_id in w_force
+            and w_force[frame_id] is not None
+        ):
             msg.w_force = w_force[frame_id]
 
         return msg
 
     # Find all possible frame ids in all dictionaries
-    frame_ids = (
-        set(w_traj_point.point.end_effector_poses.keys())
-        | set(w_traj_point.point.end_effector_velocities.keys())
-        | set(w_traj_point.point.forces.keys())
-        | set(w_traj_point.weights.w_end_effector_poses.keys())
-        | set(w_traj_point.weights.w_end_effector_velocities.keys())
-        | set(w_traj_point.weights.w_forces.keys())
+    frame_ids = set().union(
+        *[
+            set(d.keys())
+            for d in (
+                w_traj_point.point.end_effector_poses,
+                w_traj_point.point.end_effector_velocities,
+                w_traj_point.point.forces,
+                w_traj_point.weights.w_end_effector_poses,
+                w_traj_point.weights.w_end_effector_velocities,
+                w_traj_point.weights.w_forces,
+            )
+            if d is not None
+        ]
     )
 
     w_col = w_traj_point.weights.w_collision_avoidance

--- a/agimus_controller_ros/agimus_controller_ros/ros_utils.py
+++ b/agimus_controller_ros/agimus_controller_ros/ros_utils.py
@@ -6,7 +6,7 @@ from linear_feedback_controller_msgs_py.numpy_conversions import matrix_numpy_to
 
 import rclpy
 from geometry_msgs.msg import Pose, Transform, Twist, Wrench
-from agimus_msgs.msg import MpcInput, MpcDebug, Residual
+from agimus_msgs.msg import MpcEEInput, MpcInput, MpcDebug, Residual
 from rclpy.node import Node
 from rcl_interfaces.srv import GetParameters
 from rcl_interfaces.msg import ParameterValue
@@ -32,6 +32,11 @@ def ros_pose_to_array(pose: Pose) -> npt.NDArray[np.float64]:
             pose.orientation.w,
         ]
     )
+
+
+def ros_pose_to_se3(pose: Pose) -> pin.SE3:
+    """Convert geometry_msgs.msg.Pose to a Pinocchio SE3 object"""
+    return pin.XYZQUATToSE3(ros_pose_to_array(pose))
 
 
 def array_to_ros_pose(pose_array: npt.NDArray[np.float64]) -> Pose:
@@ -169,9 +174,6 @@ def mpc_msg_to_weighted_traj_point(
     msg: MpcInput, time_ns: int
 ) -> WeightedTrajectoryPoint:
     """Build WeightedTrajectoryPoint object from MPCInput msg."""
-    xyz_quat_pose = ros_pose_to_array(msg.pose)
-    twist = ros_twist_to_motion(msg.twist)
-    force = ros_wrench_to_force(msg.force)
     traj_point = TrajectoryPoint(
         id=msg.id,
         time_ns=time_ns,
@@ -179,9 +181,15 @@ def mpc_msg_to_weighted_traj_point(
         robot_velocity=np.array(msg.qdot, dtype=np.float64),
         robot_acceleration=np.array(msg.qddot, dtype=np.float64),
         robot_effort=np.array(msg.robot_effort, dtype=np.float64),
-        end_effector_poses={msg.ee_frame_name: pin.XYZQUATToSE3(xyz_quat_pose)},
-        end_effector_velocities={msg.ee_frame_name: twist},
-        forces={msg.ee_frame_name: force},
+        end_effector_poses={
+            data.frame_id: ros_pose_to_se3(data.pose) for data in msg.ee_inputs
+        },
+        end_effector_velocities={
+            data.frame_id: ros_twist_to_motion(data.twist) for data in msg.ee_inputs
+        },
+        forces={
+            data.frame_id: ros_wrench_to_force(data.force) for data in msg.ee_inputs
+        },
     )
 
     traj_weights = TrajectoryPointWeights(
@@ -189,10 +197,12 @@ def mpc_msg_to_weighted_traj_point(
         w_robot_velocity=np.array(msg.w_qdot, dtype=np.float64),
         w_robot_acceleration=np.array(msg.w_qddot, dtype=np.float64),
         w_robot_effort=np.array(msg.w_robot_effort, dtype=np.float64),
-        w_end_effector_poses={msg.ee_frame_name: np.array(msg.w_pose)},
-        w_end_effector_velocities={msg.ee_frame_name: np.array(msg.w_twist)},
-        w_forces={msg.ee_frame_name: np.array(msg.w_force)},
         w_collision_avoidance=msg.w_collision_avoidance,
+        w_end_effector_poses={data.frame_id: data.w_pose for data in msg.ee_inputs},
+        w_end_effector_velocities={
+            data.frame_id: data.w_twist for data in msg.ee_inputs
+        },
+        w_forces={data.frame_id: data.w_force for data in msg.ee_inputs},
     )
 
     return WeightedTrajectoryPoint(point=traj_point, weights=traj_weights)
@@ -202,56 +212,70 @@ def weighted_traj_point_to_mpc_msg(w_traj_point: WeightedTrajectoryPoint) -> Mpc
     """Build WeightedTrajectoryPoint object from MPCInput msg."""
     # get the first key of the dictionary
 
-    ee_frame_name = next(iter(w_traj_point.point.end_effector_poses.keys()))
+    def _generate_mpc_ee_input(frame_id: str) -> MpcEEInput:
+        msg = MpcEEInput(frame_id=frame_id)
 
-    msg = MpcInput()
-    msg.id = w_traj_point.point.id
-    msg.w_q = list(w_traj_point.weights.w_robot_configuration)
-    msg.w_qdot = list(w_traj_point.weights.w_robot_velocity)
-    msg.w_qddot = list(w_traj_point.weights.w_robot_acceleration)
-    msg.w_robot_effort = list(w_traj_point.weights.w_robot_effort)
+        pose = w_traj_point.point.end_effector_poses
+        if frame_id in pose and pose[frame_id] is not None:
+            wMee = pose[frame_id]
+            if isinstance(wMee, pin.SE3):
+                # This is the type defined in the annotation of the class definition
+                # However, this is not enforced, hence the else.
+                wMee = pin.SE3ToXYZQUAT(wMee)
+            else:
+                pass
+            msg.pose = array_to_ros_pose(wMee)
 
-    w_poses = w_traj_point.weights.w_end_effector_poses
-    if w_poses and len(w_poses) > 0:
-        msg.w_pose = w_poses[ee_frame_name]
+        twist = w_traj_point.point.end_effector_velocities
+        if frame_id in twist and twist[frame_id] is not None:
+            msg.twist = motion_to_ros_twist(twist[frame_id])
 
-    w_vel = w_traj_point.weights.w_end_effector_velocities
-    if w_vel and len(w_vel) > 0:
-        msg.w_twist = w_vel[ee_frame_name]
+        force = w_traj_point.point.forces
+        if frame_id in force and force[frame_id] is not None:
+            msg.force = force_to_ros_wrench(force[frame_id])
 
-    w_force = w_traj_point.weights.w_forces
-    if w_force and len(w_force) > 0:
-        msg.w_force = w_force[ee_frame_name]
+        w_pose = w_traj_point.weights.w_end_effector_poses
+        if frame_id in w_pose and w_pose[frame_id] is not None:
+            msg.w_pose = w_pose[frame_id]
 
-    msg.q = list(w_traj_point.point.robot_configuration)
-    msg.qdot = list(w_traj_point.point.robot_velocity)
-    msg.qddot = list(w_traj_point.point.robot_acceleration)
-    msg.robot_effort = list(w_traj_point.point.robot_effort)
+        w_twist = w_traj_point.weights.w_end_effector_velocities
+        if frame_id in w_twist and w_twist[frame_id] is not None:
+            msg.w_twist = w_twist[frame_id]
 
-    pose = w_traj_point.point.end_effector_poses
-    if pose and len(pose) > 0:
-        wMee = pose[ee_frame_name]
-        if isinstance(wMee, pin.SE3):
-            # This is the type defined in the annotation of the class definition
-            # However, this is not enforced, hence the else.
-            wMee = pin.SE3ToXYZQUAT(wMee)
-        else:
-            pass
-        msg.pose = array_to_ros_pose(wMee)
+        w_force = w_traj_point.weights.w_forces
+        if frame_id in w_force and w_force[frame_id] is not None:
+            msg.w_force = w_force[frame_id]
 
-    vel = w_traj_point.point.end_effector_velocities
-    if vel and len(vel) > 0:
-        msg.twist = motion_to_ros_twist(vel[ee_frame_name])
+        return msg
 
-    force = w_traj_point.point.forces
-    if force and len(force):
-        msg.force = force_to_ros_wrench(force[ee_frame_name])
+    # Find all possible frame ids in all dictionaries
+    frame_ids = (
+        set(w_traj_point.point.end_effector_poses.keys())
+        | set(w_traj_point.point.end_effector_velocities.keys())
+        | set(w_traj_point.point.forces.keys())
+        | set(w_traj_point.weights.w_end_effector_poses.keys())
+        | set(w_traj_point.weights.w_end_effector_velocities.keys())
+        | set(w_traj_point.weights.w_forces.keys())
+    )
 
-    if w_traj_point.weights.w_collision_avoidance:
-        msg.w_collision_avoidance = w_traj_point.weights.w_collision_avoidance
+    w_col = w_traj_point.weights.w_collision_avoidance
 
-    msg.ee_frame_name = ee_frame_name
-    return msg
+    return MpcInput(
+        id=w_traj_point.point.id,
+        # Targets
+        q=list(w_traj_point.point.robot_configuration),
+        qdot=list(w_traj_point.point.robot_velocity),
+        qddot=list(w_traj_point.point.robot_acceleration),
+        robot_effort=list(w_traj_point.point.robot_effort),
+        # Weights
+        w_q=list(w_traj_point.weights.w_robot_configuration),
+        w_qdot=list(w_traj_point.weights.w_robot_velocity),
+        w_qddot=list(w_traj_point.weights.w_robot_acceleration),
+        w_robot_effort=list(w_traj_point.weights.w_robot_effort),
+        w_collision_avoidance=w_col if w_col is not None else 0.0,
+        # End Effectors
+        ee_inputs=[_generate_mpc_ee_input(frame_id) for frame_id in frame_ids],
+    )
 
 
 def mpc_debug_data_to_msg(mpc_debug_data: MPCDebugData) -> MpcDebug:


### PR DESCRIPTION
Accompanying PR to https://github.com/agimus-project/agimus_msgs/pull/42
Generally it should be backwards compatible and not break unrelated demos.

By default residuals assume single end effector and just pick the first on from the list. This PR adds option for several frames to be used at once, while adding new set of residuals with `Static` in the name. This implies the residual can work with only one frame, but allows for several residuals of the same type to be used with different frames.