### PR TITLE
Implement instant buffer and add parameters for constant buffer

### DIFF
--- a/agimus_controller/agimus_controller/trajectory.py
+++ b/agimus_controller/agimus_controller/trajectory.py
@@ -231,6 +231,57 @@ class TrajectoryBuffer(object):
         self._buffer[index] = value
 
 
+class ConstantTrajectoryBuffer(TrajectoryBuffer):
+    """Reactive trajectory buffer for teleoperation.
+
+    Instead of a sliding FIFO window, every call to .horizon returns N+1 copies
+    of the latest received point.  This forces the MPC to treat the current
+    hand pose as the target for the entire horizon, giving maximum reactivity.
+
+    Interface is identical to TrajectoryBuffer so the controller needs no other
+    changes beyond selecting this class.
+    """
+
+    def __init__(self, dt_factor_n_seq: DTFactorsNSeq):
+        self._latest_point: WeightedTrajectoryPoint | None = None
+        self.dt_factor_n_seq = deepcopy(dt_factor_n_seq)
+        self.horizon_indexes = self.compute_horizon_indexes()
+        self._n_horizon_states = len(self.horizon_indexes)
+
+    def append(self, item: WeightedTrajectoryPoint) -> None:
+        self._latest_point = item
+
+    def pop(self, index=-1) -> WeightedTrajectoryPoint:
+        return self._latest_point
+
+    def clear_past(self) -> None:
+        # No sliding window to advance — the single stored point is always current.
+        pass
+
+    @property
+    def horizon(self) -> list:
+        assert self._latest_point is not None, (
+            "ConstantTrajectoryBuffer: no point received yet."
+        )
+        # Return the same object N+1 times.  The OCP reads but does not mutate
+        # trajectory points, so sharing the reference is safe and allocation-free.
+        return [self._latest_point] * self._n_horizon_states
+
+    def __len__(self) -> int:
+        if self._latest_point is None:
+            return 0
+        # Conceptually we can supply as many copies as needed, so return a value
+        # that always satisfies buffer_has_enough_data(ratio) for any ratio <= 3:
+        #   len * dt >= ratio * total_time  →  len >= ratio * horizon_indexes[-1]
+        return 3 * (self.horizon_indexes[-1] + 1)
+
+    def __getitem__(self, _):
+        return self._latest_point
+
+    def __setitem__(self, _, value):
+        self._latest_point = value
+
+
 def interpolate_weights(
     p1: TrajectoryPointWeights, p2: TrajectoryPointWeights, alpha: float
 ) -> TrajectoryPointWeights:

--- a/agimus_controller/tests/test_buffer.py
+++ b/agimus_controller/tests/test_buffer.py
@@ -5,6 +5,7 @@ import unittest
 
 from agimus_controller.ocp_param_base import DTFactorsNSeq
 from agimus_controller.trajectory import (
+    ConstantTrajectoryBuffer,
     TrajectoryBuffer,
     TrajectoryPoint,
     TrajectoryPointWeights,
@@ -136,6 +137,126 @@ class TestTrajectoryBuffer(unittest.TestCase):
             deepcopy(obj.horizon),
             [obj[index] for index in horizon_indexes],
         )
+
+
+class TestConstantTrajectoryBuffer(unittest.TestCase):
+    """Unit tests for ConstantTrajectoryBuffer."""
+
+    def __init__(self, methodName="runTest"):
+        super().__init__(methodName)
+        self.nv = randint(10, 100)
+        self.nq = self.nv + 1
+        self.n_controls = 10
+        self.dt_factor_n_seq = DTFactorsNSeq(factors=[1], n_steps=[self.n_controls])
+        self.dt = 0.01
+        self.dt_ns = int(1e9 * self.dt)
+
+    def _make_point(self, time_ns=0):
+        return WeightedTrajectoryPoint(
+            point=TrajectoryPoint(
+                time_ns=time_ns,
+                robot_configuration=np.random.random(self.nq),
+                robot_velocity=np.random.random(self.nv),
+                robot_acceleration=np.random.random(self.nv),
+                robot_effort=np.random.random(self.nv),
+            ),
+            weights=TrajectoryPointWeights(
+                w_robot_configuration=np.random.random(self.nv),
+                w_robot_velocity=np.random.random(self.nv),
+                w_robot_acceleration=np.random.random(self.nv),
+                w_robot_effort=np.random.random(self.nv),
+            ),
+        )
+
+    def test_empty_buffer_raises_on_horizon(self):
+        """Accessing .horizon before any append must raise AssertionError."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        with self.assertRaises(AssertionError):
+            _ = obj.horizon
+
+    def test_empty_buffer_len_is_zero(self):
+        """len() of an empty buffer must be 0."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        self.assertEqual(len(obj), 0)
+
+    def test_len_sufficient_after_one_append(self):
+        """After a single append, len() must satisfy buffer_has_enough_data for any ratio <= 3."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        obj.append(self._make_point())
+        # len must be > horizon_indexes[-1]
+        self.assertGreater(len(obj), obj.horizon_indexes[-1])
+
+    def test_horizon_length(self):
+        """horizon must return exactly n_controls + 1 elements."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        obj.append(self._make_point())
+        self.assertEqual(len(obj.horizon), self.n_controls + 1)
+
+    def test_horizon_all_same_object(self):
+        """All elements of horizon must be the same object (no copies)."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        point = self._make_point()
+        obj.append(point)
+        horizon = obj.horizon
+        for h in horizon:
+            self.assertIs(h, point)
+
+    def test_append_replaces_latest_point(self):
+        """Each append replaces the stored point; horizon reflects the most recent one."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        for i in range(5):
+            pt = self._make_point(time_ns=i * self.dt_ns)
+            obj.append(pt)
+        last_pt = self._make_point(time_ns=99 * self.dt_ns)
+        obj.append(last_pt)
+        for h in obj.horizon:
+            self.assertIs(h, last_pt)
+
+    def test_clear_past_is_noop(self):
+        """clear_past must not change len() or the stored point."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        pt = self._make_point()
+        obj.append(pt)
+        length_before = len(obj)
+        obj.clear_past()
+        self.assertEqual(len(obj), length_before)
+        self.assertIs(obj.horizon[0], pt)
+
+    def test_getitem_always_returns_latest(self):
+        """__getitem__ with any index must return the latest point."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        pt = self._make_point()
+        obj.append(pt)
+        for idx in [0, 5, 100, -1]:
+            self.assertIs(obj[idx], pt)
+
+    def test_setitem_updates_latest_point(self):
+        """__setitem__ must update the stored point regardless of the index used."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        obj.append(self._make_point())
+        new_pt = self._make_point(time_ns=42)
+        obj[0] = new_pt
+        for h in obj.horizon:
+            self.assertIs(h, new_pt)
+
+    def test_pop_returns_latest_point(self):
+        """pop() must return the latest point (no removal occurs)."""
+        obj = ConstantTrajectoryBuffer(self.dt_factor_n_seq)
+        pt = self._make_point()
+        obj.append(pt)
+        result = obj.pop()
+        self.assertIs(result, pt)
+        # Point must still be accessible after pop
+        self.assertIs(obj.horizon[0], pt)
+
+    def test_complex_dt_factor_n_seq_horizon_length(self):
+        """horizon length must equal sum(n_steps) + 1 for non-trivial dt_factor_n_seq."""
+        dt_factor_n_seq = DTFactorsNSeq(factors=[1, 2, 3], n_steps=[3, 3, 3])
+        obj = ConstantTrajectoryBuffer(dt_factor_n_seq)
+        pt = self._make_point()
+        obj.append(pt)
+        expected_len = sum(dt_factor_n_seq.n_steps) + 1
+        self.assertEqual(len(obj.horizon), expected_len)
 
 
 if __name__ == "__main__":

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -545,7 +545,6 @@ class AgimusController(Node, RobotModelsMixin):
             self.ocp_x0_pub.publish(self.sensor_msg)
             mpc_debug_msg = mpc_debug_data_to_msg(self.mpc.mpc_debug_data)
             self.mpc_debug_pub.publish(mpc_debug_msg)
-        
 
 
 def main(args=None) -> None:

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -163,12 +163,11 @@ class AgimusController(Node, RobotModelsMixin):
         self.param_listener = agimus_controller_params.ParamListener(self)
         self.params = self.param_listener.get_params()
         self.params.ocp.armature = np.array(self.params.ocp.armature)
-        use_constant_buffer = (
-            self.declare_parameter("use_constant_buffer", False)
-            .get_parameter_value()
-            .bool_value
+        buffer_cls = (
+            ConstantTrajectoryBuffer
+            if self.params.trajectory_buffer == "constant"
+            else TrajectoryBuffer
         )
-        buffer_cls = ConstantTrajectoryBuffer if use_constant_buffer else TrajectoryBuffer
         self.traj_buffer = buffer_cls(self.params.ocp.dt_factor_n_seq)
         self.params.collision_pairs = [
             (

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -38,6 +38,8 @@ from agimus_controller.warm_start_shift_previous_solution import (
 )
 from agimus_controller.factory.robot_model import RobotModels, RobotModelParameters
 
+import crocoddyl_plotter
+
 
 from agimus_controller_ros.ros_utils import (
     mpc_msg_to_weighted_traj_point,
@@ -48,7 +50,11 @@ from agimus_controller_ros.ros_utils import (
 )
 
 
-from agimus_controller.trajectory import TrajectoryBuffer, TrajectoryPoint
+from agimus_controller.trajectory import (
+    ConstantTrajectoryBuffer,
+    TrajectoryBuffer,
+    TrajectoryPoint,
+)
 from agimus_controller_ros.agimus_controller_parameters import agimus_controller_params
 
 
@@ -157,7 +163,13 @@ class AgimusController(Node, RobotModelsMixin):
         self.param_listener = agimus_controller_params.ParamListener(self)
         self.params = self.param_listener.get_params()
         self.params.ocp.armature = np.array(self.params.ocp.armature)
-        self.traj_buffer = TrajectoryBuffer(self.params.ocp.dt_factor_n_seq)
+        use_constant_buffer = (
+            self.declare_parameter("use_constant_buffer", False)
+            .get_parameter_value()
+            .bool_value
+        )
+        buffer_cls = ConstantTrajectoryBuffer if use_constant_buffer else TrajectoryBuffer
+        self.traj_buffer = buffer_cls(self.params.ocp.dt_factor_n_seq)
         self.params.collision_pairs = [
             (
                 self.params.get_entry(collision_pair_name).first,
@@ -534,6 +546,7 @@ class AgimusController(Node, RobotModelsMixin):
             self.ocp_x0_pub.publish(self.sensor_msg)
             mpc_debug_msg = mpc_debug_data_to_msg(self.mpc.mpc_debug_data)
             self.mpc_debug_pub.publish(mpc_debug_msg)
+        
 
 
 def main(args=None) -> None:

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
@@ -38,8 +38,6 @@ from agimus_controller.warm_start_shift_previous_solution import (
 )
 from agimus_controller.factory.robot_model import RobotModels, RobotModelParameters
 
-import crocoddyl_plotter
-
 
 from agimus_controller_ros.ros_utils import (
     mpc_msg_to_weighted_traj_point,

--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller_parameters.yaml
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller_parameters.yaml
@@ -70,6 +70,12 @@ agimus_controller_params:
     type: bool
     default_value: False
     description: "When True, the OCP result is always published with a delay of dt but OCP uses a delay compensation. When False, the result is published as soon as possible."
+  trajectory_buffer:
+    type: string
+    default_value: "standard"
+    description: "Trajectory buffer strategy. 'standard': sliding FIFO window (trajectory following). 'constant': always replicate the latest point (reactive teleoperation)."
+    validation:
+      one_of<>: ["standard", "constant"]
   rate:
     type: double
     default_value: 100.0


### PR DESCRIPTION
This pull request introduces a new trajectory buffer strategy to support highly reactive teleoperation, configurable via a new parameter. The main change is the addition of the `ConstantTrajectoryBuffer` class, which always supplies the latest received trajectory point as the target for the entire prediction horizon. This behavior can now be selected through the new `trajectory_buffer` parameter, allowing seamless switching between standard trajectory following and reactive teleoperation modes.

**Trajectory Buffer Enhancements:**

* Added `ConstantTrajectoryBuffer` class in `trajectory.py`, which replicates the latest trajectory point for the entire horizon, enabling maximum reactivity for teleoperation scenarios. The interface matches `TrajectoryBuffer` for drop-in replacement.
* Updated controller initialization in `agimus_controller.py` to select between `TrajectoryBuffer` and `ConstantTrajectoryBuffer` based on the new `trajectory_buffer` parameter.
* Modified imports in `agimus_controller.py` to include `ConstantTrajectoryBuffer`.

**Configuration Improvements:**

* Added a new `trajectory_buffer` parameter to `agimus_controller_parameters.yaml`, allowing users to choose between "standard" (FIFO window) and "constant" (replicate latest point) buffer strategies, with validation for accepted values.
