### PR TITLE
Update agimus_controller_parameters.yaml

### DIFF
--- a/agimus_controller_ros/agimus_controller_ros/agimus_controller_parameters.yaml
+++ b/agimus_controller_ros/agimus_controller_ros/agimus_controller_parameters.yaml
@@ -75,7 +75,7 @@ agimus_controller_params:
     default_value: "standard"
     description: "Trajectory buffer strategy. 'standard': sliding FIFO window (trajectory following). 'constant': always replicate the latest point (reactive teleoperation)."
     validation:
-      one_of<>: ["standard", "constant"]
+      one_of<>: [["standard", "constant"]]
   rate:
     type: double
     default_value: 100.0


### PR DESCRIPTION
Missing brackets near the one_of validation. The generated parameter code (agimus_controller_parameters.py) than fails because inconsistent ParameterValidators.one_of signature.